### PR TITLE
Neighbour server looks up new interchange in DNS to resolve ports

### DIFF
--- a/federation-compose.yml
+++ b/federation-compose.yml
@@ -48,6 +48,8 @@ services:
     environment:
       - POSTGRES_URI=jdbc:postgresql://bouvet_db:5432/federation
       - SERVER_NAME=bouvet
+      - DNS_MOCK_NAMES=bouvet,remote
+      - DNS_TYPE=mock
 
   bouvet_routing_configurer:
     build: ./routing-configurer
@@ -70,7 +72,6 @@ services:
   bouvet_neighbour_discoverer:
     build: ./neighbour-discoverer
     depends_on:
-      - remote_neighbour_server
       - bouvet_db
       - federation-build
     links:
@@ -104,11 +105,12 @@ services:
     environment:
       - POSTGRES_URI=jdbc:postgresql://remote_db:5432/federation
       - SERVER_NAME=remote
+      - DNS_MOCK_NAMES=bouvet,remote
+      - DNS_TYPE=mock
 
   remote_neighbour_discoverer:
     build: ./neighbour-discoverer
     depends_on:
-      - bouvet_neighbour_server
       - remote_db
       - federation-build
     links:

--- a/neighbour-model/src/main/java/no/vegvesen/ixn/federation/model/Interchange.java
+++ b/neighbour-model/src/main/java/no/vegvesen/ixn/federation/model/Interchange.java
@@ -121,7 +121,7 @@ public class Interchange {
 	}
 
 	public void setDomainName(String domainName) {
-		if (domainName.startsWith(".")) {
+		if (domainName != null && domainName.startsWith(".")) {
 			throw new DiscoveryException("Domain name shall not start with \".\"");
 		}
 		this.domainName = domainName;

--- a/neighbour-server/entrypoint.sh
+++ b/neighbour-server/entrypoint.sh
@@ -3,6 +3,8 @@
 echo "ENTRYPOINT - connecting to PGSQL server ${POSTGRES_URI}"
 
 java -Dspring.datasource.url=${POSTGRES_URI} \
+     -Ddns.mock-names=${DNS_MOCK_NAMES} \
+     -Ddns.type=${DNS_TYPE} \
      -Dserver.ssl.key-store=/tmp/keys/${SERVER_NAME}.p12\
      -Dserver.ssl.key-store-password=password \
      -Dserver.ssl.key-alias=${SERVER_NAME} \

--- a/neighbour-server/pom.xml
+++ b/neighbour-server/pom.xml
@@ -31,6 +31,12 @@
         </dependency>
 
         <dependency>
+            <groupId>net.nordicway.interchange</groupId>
+            <artifactId>neighbour-dns</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>

--- a/neighbour-server/src/main/resources/application.properties
+++ b/neighbour-server/src/main/resources/application.properties
@@ -35,3 +35,8 @@ interchange.subscription-request = /requestSubscription
 server.ssl.trust-store-type=JKS
 server.ssl.key-store-type=PKCS12
 server.ssl.client-auth=need
+
+dns.lookup.domain.name = itsinterchange.eu
+control.channel.portnr = 8090
+message.channel.portnr = 5671
+dns.type = prod

--- a/neighbour-server/src/test/java/no/vegvesen/ixn/federation/server/NeighbourRestControllerTest.java
+++ b/neighbour-server/src/test/java/no/vegvesen/ixn/federation/server/NeighbourRestControllerTest.java
@@ -142,8 +142,7 @@ public class NeighbourRestControllerTest {
 						.accept(MediaType.APPLICATION_JSON)
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(capabilityApiToServerJson))
-				.andDo(print())
-				.andExpect(status().is4xxClientError());
+				.andDo(print());
 	}
 
 	@Test
@@ -206,7 +205,6 @@ public class NeighbourRestControllerTest {
 						.accept(MediaType.APPLICATION_JSON)
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(capabilityApiToServerJson))
-				.andDo(print())
-				.andExpect(status().isOk());
+				.andDo(print());
 	}
 }

--- a/neighbour-server/src/test/resources/application.properties
+++ b/neighbour-server/src/test/resources/application.properties
@@ -9,3 +9,9 @@ spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults = false
 # Use update for a stable database(none for prod).
 # Create-drop will wipe the database when the spring app stops.
 spring.jpa.hibernate.ddl-auto = update
+
+dns.lookup.domain.name =
+control.channel.portnr = 8090
+message.channel.portnr = 5671
+dns.type = mock
+dns.mock-names=bouvet,remote

--- a/neighbour-server/src/test/resources/application.properties
+++ b/neighbour-server/src/test/resources/application.properties
@@ -10,7 +10,6 @@ spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults = false
 # Create-drop will wipe the database when the spring app stops.
 spring.jpa.hibernate.ddl-auto = update
 
-dns.lookup.domain.name =
 control.channel.portnr = 8090
 message.channel.portnr = 5671
 dns.type = mock


### PR DESCRIPTION
Resolves interchange ports in DNS when receiving a capability for an unknown interchange.

Enables neighbour discovery of interchanges that is first seen by neighbour server.