### PR TITLE
Update qpid groups on discovery

### DIFF
--- a/neighbour-discoverer/src/main/java/no/vegvesen/ixn/federation/discoverer/NeighbourDiscoverer.java
+++ b/neighbour-discoverer/src/main/java/no/vegvesen/ixn/federation/discoverer/NeighbourDiscoverer.java
@@ -147,16 +147,14 @@ public class NeighbourDiscoverer {
 
 	public Interchange updateFedInStatus(Interchange neighbour) {
 
-		if (neighbour.getFedIn().subscriptionRequestAccepted() && neighbour.getFedIn().allSubscriptionsHaveFinalStatus()) {
-
-			logger.info("All subscriptions in neighbour fedIn have final statuses. Setting status of fedIn to ESTABLISHED");
+		if (neighbour.getFedIn().subscriptionRequestEstablished()) {
+			logger.info("At least one subscription in fedIn has status CREATED. Setting status of fedIn to ESTABLISHED");
 			neighbour.getFedIn().setStatus(SubscriptionRequest.SubscriptionRequestStatus.ESTABLISHED);
-
-		} else if (!neighbour.getFedIn().subscriptionRequestAccepted()) {
+		} else if (neighbour.getFedIn().subscriptionRequestRejected()) {
 			logger.info("All subscriptions in neighbour fedIn were rejected. Setting status of fedIn to REJECTED");
 			neighbour.getFedIn().setStatus(SubscriptionRequest.SubscriptionRequestStatus.REJECTED);
 		} else {
-			logger.info("Some subscriptions in neighbour fedIn do not have a final status. Keeping status of fedIn REQUESTED");
+			logger.info("Some subscriptions in neighbour fedIn do not have a final status or have not been rejected. Keeping status of fedIn REQUESTED");
 			neighbour.getFedIn().setStatus(SubscriptionRequest.SubscriptionRequestStatus.REQUESTED);
 		}
 

--- a/neighbour-discoverer/src/main/java/no/vegvesen/ixn/federation/discoverer/NeighbourDiscoverer.java
+++ b/neighbour-discoverer/src/main/java/no/vegvesen/ixn/federation/discoverer/NeighbourDiscoverer.java
@@ -145,6 +145,24 @@ public class NeighbourDiscoverer {
 		return calculatedSubscriptions;
 	}
 
+	public Interchange updateFedInStatus(Interchange neighbour) {
+
+		if (neighbour.getFedIn().subscriptionRequestAccepted() && neighbour.getFedIn().allSubscriptionsHaveFinalStatus()) {
+
+			logger.info("All subscriptions in neighbour fedIn have final statuses. Setting status of fedIn to ESTABLISHED");
+			neighbour.getFedIn().setStatus(SubscriptionRequest.SubscriptionRequestStatus.ESTABLISHED);
+
+		} else if (!neighbour.getFedIn().subscriptionRequestAccepted()) {
+			logger.info("All subscriptions in neighbour fedIn were rejected. Setting status of fedIn to REJECTED");
+			neighbour.getFedIn().setStatus(SubscriptionRequest.SubscriptionRequestStatus.REJECTED);
+		} else {
+			logger.info("Some subscriptions in neighbour fedIn do not have a final status. Keeping status of fedIn REQUESTED");
+			neighbour.getFedIn().setStatus(SubscriptionRequest.SubscriptionRequestStatus.REQUESTED);
+		}
+
+		return neighbour;
+	}
+
 	@Scheduled(fixedRateString = "${graceful-backoff.check-interval}", initialDelayString = "${graceful-backoff.check-offset}")
 	public void gracefulBackoffPollSubscriptions() {
 
@@ -167,6 +185,8 @@ public class NeighbourDiscoverer {
 						logger.info("Successfully re-established contact with neighbour in subscription polling graceful backoff.");
 						failedSubscription.setSubscriptionStatus(polledSubscription.getSubscriptionStatus());
 						neighbour.setBackoffAttempts(0); // Reset number of back-offs to 0 after contact is re-established.
+
+						neighbour = updateFedInStatus(neighbour);
 
 					} catch (SubscriptionPollException e) {
 						// Poll was not successful
@@ -207,7 +227,10 @@ public class NeighbourDiscoverer {
 
 						subscription.setSubscriptionStatus(polledSubscription.getSubscriptionStatus());
 						subscription.setNumberOfPolls(subscription.getNumberOfPolls() + 1);
-						logger.info("Successfully polled subscription to neighbour {}. Subscription status: {}  - Number of polls: {}", neighbour.getName(), subscription.getSubscriptionStatus(), subscription.getNumberOfPolls());
+						logger.info("Successfully polled subscription. Subscription status: {}  - Number of polls: {}", subscription.getSubscriptionStatus(), subscription.getNumberOfPolls());
+
+						neighbour = updateFedInStatus(neighbour);
+
 
 					} else {
 						// Number of poll attempts exceeds allowed number of poll attempts.

--- a/neighbour-discoverer/src/test/java/no/vegvesen/ixn/federation/discoverer/NeighbourDiscovererTest.java
+++ b/neighbour-discoverer/src/test/java/no/vegvesen/ixn/federation/discoverer/NeighbourDiscovererTest.java
@@ -438,7 +438,7 @@ public class NeighbourDiscovererTest {
 	}
 
 	@Test
-	public void allSubscriptionsRejectedFlipsFedInStatusToEstablished(){
+	public void allSubscriptionsRejectedFlipsFedInStatusToRejected(){
 		Interchange spyInterchange = spy(Interchange.class);
 
 		Subscription subscription = new Subscription("where LIKE 'NO'", Subscription.SubscriptionStatus.REQUESTED);
@@ -454,6 +454,25 @@ public class NeighbourDiscovererTest {
 		neighbourDiscoverer.pollSubscriptions();
 
 		Assert.assertEquals(spyInterchange.getFedIn().getStatus(), SubscriptionRequest.SubscriptionRequestStatus.REJECTED);
+	}
+
+	@Test
+	public void subscriptionStatusAcceptedKeepsFedInStatusRequested(){
+		Interchange spyInterchange = spy(Interchange.class);
+
+		Subscription subscription = new Subscription("where LIKE 'NO'", Subscription.SubscriptionStatus.REQUESTED);
+		subscription.setNumberOfPolls(0);
+		SubscriptionRequest subscriptionRequest = new SubscriptionRequest(SubscriptionRequest.SubscriptionRequestStatus.REQUESTED, Collections.singleton(subscription));
+		spyInterchange.setFedIn(subscriptionRequest);
+		when(interchangeRepository.findInterchangesWithSubscriptionToPoll()).thenReturn(Collections.singletonList(spyInterchange));
+
+		Subscription createdSubscription = new Subscription("where LIKE 'NO'", Subscription.SubscriptionStatus.ACCEPTED);
+		when(neighbourRESTFacade.pollSubscriptionStatus(any(Subscription.class), any(Interchange.class))).thenReturn(createdSubscription);
+		when(discovererProperties.getSubscriptionPollingNumberOfAttempts()).thenReturn(7);
+
+		neighbourDiscoverer.pollSubscriptions();
+
+		Assert.assertEquals(spyInterchange.getFedIn().getStatus(), SubscriptionRequest.SubscriptionRequestStatus.REQUESTED);
 	}
 
 

--- a/neighbour-discoverer/src/test/java/no/vegvesen/ixn/federation/discoverer/NeighbourDiscovererTest.java
+++ b/neighbour-discoverer/src/test/java/no/vegvesen/ixn/federation/discoverer/NeighbourDiscovererTest.java
@@ -395,6 +395,9 @@ public class NeighbourDiscovererTest {
 		Assert.assertEquals(ericsson.getCapabilities().getStatus(), Capabilities.CapabilitiesStatus.UNREACHABLE);
 	}
 
+	/*
+		Subscription polling tests
+	 */
 
 	@Test
 	public void successfulPollOfSubscriptionCallsSaveOnRepository(){
@@ -404,9 +407,53 @@ public class NeighbourDiscovererTest {
 		ericsson.setFedIn(ericssonSubscription);
 		when(interchangeRepository.findInterchangesWithSubscriptionToPoll()).thenReturn(Collections.singletonList(ericsson));
 
+		Subscription polledSubscription = new Subscription("where LIKE 'NO'", Subscription.SubscriptionStatus.ACCEPTED);
+		when(neighbourRESTFacade.pollSubscriptionStatus(any(Subscription.class), any(Interchange.class))).thenReturn(polledSubscription);
+		when(discovererProperties.getSubscriptionPollingNumberOfAttempts()).thenReturn(7);
+
 		neighbourDiscoverer.pollSubscriptions();
 
 		verify(interchangeRepository, times(1)).save(any(Interchange.class));
+	}
+
+	@Test
+	public void allSubscriptionsHaveFinalStatusFlipsFedInStatusToEstablished(){
+
+		Interchange spyInterchange = spy(Interchange.class);
+
+		Subscription subscription = new Subscription("where LIKE 'NO'", Subscription.SubscriptionStatus.REQUESTED);
+		subscription.setNumberOfPolls(0);
+		SubscriptionRequest subscriptionRequest = new SubscriptionRequest(SubscriptionRequest.SubscriptionRequestStatus.REQUESTED, Collections.singleton(subscription));
+		spyInterchange.setFedIn(subscriptionRequest);
+		when(interchangeRepository.findInterchangesWithSubscriptionToPoll()).thenReturn(Collections.singletonList(spyInterchange));
+
+		Subscription createdSubscription = new Subscription("where LIKE 'NO'", Subscription.SubscriptionStatus.CREATED);
+		when(neighbourRESTFacade.pollSubscriptionStatus(any(Subscription.class), any(Interchange.class))).thenReturn(createdSubscription);
+		when(discovererProperties.getSubscriptionPollingNumberOfAttempts()).thenReturn(7);
+
+		neighbourDiscoverer.pollSubscriptions();
+
+		Assert.assertEquals(spyInterchange.getFedIn().getStatus(), SubscriptionRequest.SubscriptionRequestStatus.ESTABLISHED);
+
+	}
+
+	@Test
+	public void allSubscriptionsRejectedFlipsFedInStatusToEstablished(){
+		Interchange spyInterchange = spy(Interchange.class);
+
+		Subscription subscription = new Subscription("where LIKE 'NO'", Subscription.SubscriptionStatus.REQUESTED);
+		subscription.setNumberOfPolls(0);
+		SubscriptionRequest subscriptionRequest = new SubscriptionRequest(SubscriptionRequest.SubscriptionRequestStatus.REQUESTED, Collections.singleton(subscription));
+		spyInterchange.setFedIn(subscriptionRequest);
+		when(interchangeRepository.findInterchangesWithSubscriptionToPoll()).thenReturn(Collections.singletonList(spyInterchange));
+
+		Subscription createdSubscription = new Subscription("where LIKE 'NO'", Subscription.SubscriptionStatus.REJECTED);
+		when(neighbourRESTFacade.pollSubscriptionStatus(any(Subscription.class), any(Interchange.class))).thenReturn(createdSubscription);
+		when(discovererProperties.getSubscriptionPollingNumberOfAttempts()).thenReturn(7);
+
+		neighbourDiscoverer.pollSubscriptions();
+
+		Assert.assertEquals(spyInterchange.getFedIn().getStatus(), SubscriptionRequest.SubscriptionRequestStatus.REJECTED);
 	}
 
 

--- a/neighbour-model/src/main/java/no/vegvesen/ixn/federation/model/SubscriptionRequest.java
+++ b/neighbour-model/src/main/java/no/vegvesen/ixn/federation/model/SubscriptionRequest.java
@@ -17,7 +17,7 @@ public class SubscriptionRequest {
 	@Column(name="subreq_id")
 	private Integer subreq_id;
 
-	public enum SubscriptionRequestStatus{REQUESTED, ESTABLISHED, NO_OVERLAP, TEAR_DOWN, EMPTY, FAILED, UNREACHABLE}
+	public enum SubscriptionRequestStatus{REQUESTED, ESTABLISHED, NO_OVERLAP, TEAR_DOWN, EMPTY, FAILED, UNREACHABLE, REJECTED}
 
 	@Enumerated(EnumType.STRING)
 	private SubscriptionRequestStatus status = SubscriptionRequestStatus.EMPTY;
@@ -57,6 +57,27 @@ public class SubscriptionRequest {
 		if (newSubscription != null) {
 			this.subscription.addAll(newSubscription);
 		}
+	}
+
+	public boolean allSubscriptionsHaveFinalStatus(){
+		for(Subscription s : subscription){
+			if(s.getSubscriptionStatus() == Subscription.SubscriptionStatus.REQUESTED || s.getSubscriptionStatus() == Subscription.SubscriptionStatus.ACCEPTED){
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public boolean subscriptionRequestAccepted(){
+		for(Subscription s : subscription){
+			if(s.getSubscriptionStatus() == Subscription.SubscriptionStatus.REJECTED
+					|| s.getSubscriptionStatus() == Subscription.SubscriptionStatus.NO_OVERLAP
+					|| s.getSubscriptionStatus() == Subscription.SubscriptionStatus.ILLEGAL
+					|| s.getSubscriptionStatus() == Subscription.SubscriptionStatus.NOT_VALID){
+				return false;
+			}
+		}
+		return true;
 	}
 
 	@Override

--- a/neighbour-model/src/main/java/no/vegvesen/ixn/federation/model/SubscriptionRequest.java
+++ b/neighbour-model/src/main/java/no/vegvesen/ixn/federation/model/SubscriptionRequest.java
@@ -59,25 +59,24 @@ public class SubscriptionRequest {
 		}
 	}
 
-	public boolean allSubscriptionsHaveFinalStatus(){
+	public boolean subscriptionRequestRejected(){
 		for(Subscription s : subscription){
-			if(s.getSubscriptionStatus() == Subscription.SubscriptionStatus.REQUESTED || s.getSubscriptionStatus() == Subscription.SubscriptionStatus.ACCEPTED){
+			if(s.getSubscriptionStatus() == Subscription.SubscriptionStatus.CREATED
+				|| s.getSubscriptionStatus() == Subscription.SubscriptionStatus.ACCEPTED
+				|| s.getSubscriptionStatus() == Subscription.SubscriptionStatus.REQUESTED){
 				return false;
 			}
 		}
 		return true;
 	}
 
-	public boolean subscriptionRequestAccepted(){
+	public boolean subscriptionRequestEstablished(){
 		for(Subscription s : subscription){
-			if(s.getSubscriptionStatus() == Subscription.SubscriptionStatus.REJECTED
-					|| s.getSubscriptionStatus() == Subscription.SubscriptionStatus.NO_OVERLAP
-					|| s.getSubscriptionStatus() == Subscription.SubscriptionStatus.ILLEGAL
-					|| s.getSubscriptionStatus() == Subscription.SubscriptionStatus.NOT_VALID){
-				return false;
+			if(s.getSubscriptionStatus() == Subscription.SubscriptionStatus.CREATED){
+				return true;
 			}
 		}
-		return true;
+		return false;
 	}
 
 	@Override

--- a/neighbour-model/src/main/java/no/vegvesen/ixn/federation/repository/InterchangeRepository.java
+++ b/neighbour-model/src/main/java/no/vegvesen/ixn/federation/repository/InterchangeRepository.java
@@ -19,6 +19,14 @@ public interface InterchangeRepository extends CrudRepository<Interchange, Integ
 	@Query(value = "select * from interchanges i where exists(select 'x' from subscriptions s where i.ixn_id_fed_in=s.subreq_id_sub and s.subscription_status in('ACCEPTED', 'REQUESTED'));", nativeQuery = true)
 	List<Interchange> findInterchangesWithSubscriptionToPoll();
 
+	// Neighbours to add to qpid groups file: fedIn status REQUESTED or ESTABLISHED
+	@Query(value ="select * from interchanges i where exists(select 'x' from subscription_request s where i.ixn_id_fed_in=s.subreq_id and s.status in('REQUESTED', 'ESTABLISHED'))", nativeQuery = true)
+	List<Interchange> findInterchangesToAddToQpidGroups();
+
+	// Neighbours to remove from qpid groups file: fedIn status REJECTED
+	@Query(value = "select * from interchanges i where exists(select 'x' from subscription_request s where i.ixn_id_fed_in=s.subreq_id and s.status='REJECTED')", nativeQuery = true)
+	List<Interchange> findInterchangesToRemoveFromQpidGroups();
+
 	// Selectors for capability and subscription exchange
 	// Capability exchange: when neighbour capabilities is UNKNOWN
 	@Query(value = "select * from interchanges i where exists(select 'x' from capabilities c where i.ixn_id_cap=cap_id and c.status='UNKNOWN');", nativeQuery = true)

--- a/neighbour-model/src/test/java/no/vegvesen/ixn/federation/model/SubscriptionRequestTest.java
+++ b/neighbour-model/src/test/java/no/vegvesen/ixn/federation/model/SubscriptionRequestTest.java
@@ -1,0 +1,55 @@
+package no.vegvesen.ixn.federation.model;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class SubscriptionRequestTest {
+
+	private Subscription norway;
+	private Subscription sweden;
+
+	@Before
+	public void setUp(){
+		norway = new Subscription();
+		norway.setSelector("where='NO'");
+
+		sweden = new Subscription();
+		sweden.setSelector("where='SE'");
+	}
+
+	@Test
+	public void subscriptionRequestWithOneCreatedSubscriptionNotRejected(){
+		norway.setSubscriptionStatus(Subscription.SubscriptionStatus.CREATED);
+		sweden.setSubscriptionStatus(Subscription.SubscriptionStatus.REJECTED);
+		SubscriptionRequest subscriptionRequest = new SubscriptionRequest();
+		subscriptionRequest.setSubscriptions(Stream.of(norway, sweden).collect(Collectors.toSet()));
+
+		Assert.assertFalse(subscriptionRequest.subscriptionRequestRejected());
+	}
+
+	@Test
+	public void subscriptionRequestWithOneCreatedSubscriptionIsEstablished(){
+		sweden.setSubscriptionStatus(Subscription.SubscriptionStatus.CREATED);
+		norway.setSubscriptionStatus(Subscription.SubscriptionStatus.REJECTED);
+		SubscriptionRequest subscriptionRequest = new SubscriptionRequest();
+		subscriptionRequest.setSubscriptions(Stream.of(norway, sweden).collect(Collectors.toSet()));
+
+		Assert.assertTrue(subscriptionRequest.subscriptionRequestEstablished());
+	}
+
+	@Test
+	public void subscriptionRequestWithStatusRejectedIsRejected(){
+		sweden.setSubscriptionStatus(Subscription.SubscriptionStatus.NO_OVERLAP);
+		norway.setSubscriptionStatus(Subscription.SubscriptionStatus.ILLEGAL);
+		SubscriptionRequest subscriptionRequest = new SubscriptionRequest();
+		subscriptionRequest.setSubscriptions(Stream.of(norway, sweden).collect(Collectors.toSet()));
+
+		Assert.assertTrue(subscriptionRequest.subscriptionRequestRejected());
+	}
+
+
+}

--- a/neighbour-model/src/test/java/no/vegvesen/ixn/federation/repository/InterchangeRepositorySelectorIT.java
+++ b/neighbour-model/src/test/java/no/vegvesen/ixn/federation/repository/InterchangeRepositorySelectorIT.java
@@ -146,4 +146,53 @@ public class InterchangeRepositorySelectorIT {
 		Assert.assertTrue(interchangeInList(ericsson.getName(), getInterchangesWithFailedSubscriptionInFedIn));
 	}
 
+	@Test
+	public void neighbourWithFedInRequestedIsSelectedForGroups(){
+
+		ericsson.setName("ericsson-7");
+		Subscription subscription = new Subscription();
+		subscription.setSelector("where LIKE 'NO'");
+		SubscriptionRequest subscriptionRequest = new SubscriptionRequest();
+		subscriptionRequest.setSubscriptions(Collections.singleton(subscription));
+		subscriptionRequest.setStatus(SubscriptionRequest.SubscriptionRequestStatus.REQUESTED);
+		ericsson.setFedIn(subscriptionRequest);
+		interchangeRepository.save(ericsson);
+
+		List<Interchange> interchangeWithFedInRequested = interchangeRepository.findInterchangesToAddToQpidGroups();
+
+		Assert.assertTrue(interchangeInList(ericsson.getName(), interchangeWithFedInRequested));
+	}
+
+	@Test
+	public void neigbourWithFedInEstablishedIsSelectedForGroups(){
+		ericsson.setName("ericsson-8");
+		Subscription subscription = new Subscription();
+		subscription.setSelector("where LIKE 'NO'");
+		SubscriptionRequest subscriptionRequest = new SubscriptionRequest();
+		subscriptionRequest.setSubscriptions(Collections.singleton(subscription));
+		subscriptionRequest.setStatus(SubscriptionRequest.SubscriptionRequestStatus.ESTABLISHED);
+		ericsson.setFedIn(subscriptionRequest);
+		interchangeRepository.save(ericsson);
+
+		List<Interchange> interchangeWithFedInEstablished = interchangeRepository.findInterchangesToAddToQpidGroups();
+
+		Assert.assertTrue(interchangeInList(ericsson.getName(), interchangeWithFedInEstablished));
+	}
+
+	@Test
+	public void neighbourWithFedInRejectedIsSelectedForRemovalFromGroups(){
+		ericsson.setName("ericsson-9");
+		Subscription subscription = new Subscription();
+		subscription.setSelector("where LIKE 'NO'");
+		SubscriptionRequest subscriptionRequest = new SubscriptionRequest();
+		subscriptionRequest.setSubscriptions(Collections.singleton(subscription));
+		subscriptionRequest.setStatus(SubscriptionRequest.SubscriptionRequestStatus.REJECTED);
+		ericsson.setFedIn(subscriptionRequest);
+		interchangeRepository.save(ericsson);
+
+		List<Interchange> interchangeWithFedInRejected = interchangeRepository.findInterchangesToRemoveFromQpidGroups();
+
+		Assert.assertTrue(interchangeInList(ericsson.getName(), interchangeWithFedInRejected));
+	}
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -117,9 +117,9 @@
             </dependency>
 
             <dependency>
-                <groupId>com.googlecode.json-simple</groupId>
-                <artifactId>json-simple</artifactId>
-                <version>1.1.1</version>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>20180813</version>
             </dependency>
 
             <dependency>

--- a/qpid/local/groups
+++ b/qpid/local/groups
@@ -1,2 +1,3 @@
-messaging-users.users=guest,king_harald,king_gustaf,remote.itsinterchange.eu,local.itsinterchange.eu
-administrators.users=qpid-admin,local.itsinterchange.eu
+federated-interchanges.users=
+administrators.users=local.itsinterchange.eu,qpid-admin
+service-providers.users=guest,king_gustaf,king_harald

--- a/qpid/local/vhost.json
+++ b/qpid/local/vhost.json
@@ -153,7 +153,7 @@
         },
         {
           "objectType": "EXCHANGE",
-          "identity": "messaging-users",
+          "identity": "service-providers",
           "operation": "PUBLISH",
           "outcome": "ALLOW_LOG",
           "attributes": {
@@ -163,7 +163,7 @@
         },
         {
           "objectType" : "EXCHANGE",
-          "identity" : "messaging-users",
+          "identity" : "federated-interchanges",
           "operation" : "PUBLISH",
           "outcome" : "ALLOW_LOG",
           "attributes" : {
@@ -172,7 +172,14 @@
         },
         {
           "objectType": "VIRTUALHOST",
-          "identity": "messaging-users",
+          "identity": "federated-interchanges",
+          "operation": "ACCESS",
+          "outcome": "ALLOW_LOG",
+          "attributes": {}
+        },
+        {
+          "objectType": "VIRTUALHOST",
+          "identity": "service-providers",
           "operation": "ACCESS",
           "outcome": "ALLOW_LOG",
           "attributes": {
@@ -181,7 +188,7 @@
         },
         {
           "objectType": "QUEUE",
-          "identity": "messaging-users",
+          "identity": "service-providers",
           "operation": "CONSUME",
           "outcome": "ALLOW_LOG",
           "attributes": {

--- a/qpid/remote/groups
+++ b/qpid/remote/groups
@@ -1,2 +1,3 @@
-messaging-users.users=guest,king_harald,king_gustaf,remote.itsinterchange.eu,local.itsinterchange.eu
+federated-interchanges.users=
 administrators.users=qpid-admin,remote.itsinterchange.eu
+service-providers.users=guest,king_gustaf,king_harald

--- a/qpid/remote/vhost.json
+++ b/qpid/remote/vhost.json
@@ -152,8 +152,33 @@
           "attributes": {}
         },
         {
+          "objectType": "VIRTUALHOST",
+          "identity": "federated-interchanges",
+          "operation": "ACCESS",
+          "outcome": "ALLOW_LOG",
+          "attributes": {}
+        },
+        {
+          "objectType" : "EXCHANGE",
+          "identity" : "federated-interchanges",
+          "operation" : "PUBLISH",
+          "outcome" : "ALLOW_LOG",
+          "attributes" : {
+            "NAME" : "fedEx"
+          }
+        },
+        {
+          "objectType": "VIRTUALHOST",
+          "identity": "service-providers",
+          "operation": "ACCESS",
+          "outcome": "ALLOW_LOG",
+          "attributes": {
+            "NAME": "remote.itsinterchange.eu"
+          }
+        },
+        {
           "objectType": "EXCHANGE",
-          "identity": "messaging-users",
+          "identity": "service-providers",
           "operation": "PUBLISH",
           "outcome": "ALLOW_LOG",
           "attributes": {
@@ -162,17 +187,8 @@
           }
         },
         {
-          "objectType": "VIRTUALHOST",
-          "identity": "messaging-users",
-          "operation": "ACCESS",
-          "outcome": "ALLOW_LOG",
-          "attributes": {
-            "NAME": "remote.itsinterchange.eu"
-          }
-        },
-        {
           "objectType": "QUEUE",
-          "identity": "messaging-users",
+          "identity": "service-providers",
           "operation": "CONSUME",
           "outcome": "ALLOW_LOG",
           "attributes": {

--- a/routing-configurer/pom.xml
+++ b/routing-configurer/pom.xml
@@ -39,9 +39,10 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
         </dependency>
 
         <dependency>
@@ -50,7 +51,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 
     <profiles>
         <profile>

--- a/routing-configurer/pom.xml
+++ b/routing-configurer/pom.xml
@@ -97,7 +97,7 @@
                                         <volumes>
                                             <bind>
                                                 <volume>
-                                                    ${project.basedir}/src/test/resources/qpid:/config
+                                                    ${project.basedir}/target/test-classes/qpid:/config
                                                 </volume>
                                                 <volume>
                                                     ${project.basedir}/src/test/resources/jks:/jks

--- a/routing-configurer/src/main/resources/application.properties
+++ b/routing-configurer/src/main/resources/application.properties
@@ -10,11 +10,14 @@ spring.jpa.hibernate.ddl-auto = update
 # logging
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg %ex{full}%n
 logging.level.org.hibernate.SQL=warn
+logging.level.no.vegvesen=debug
 
 # Don't start neighbour discoverer as tomcat server.
 spring.main.web-application-type= NONE
 
 routing-configurer.interval=10000
+routing-configurer.groups-interval.add = 9000
+routing-configurer.groups-interval.remove = 15000
 
 routing-configurer.ssl.trust-store-type=JKS
 routing-configurer.ssl.key-store-type=PKCS12

--- a/routing-configurer/src/test/java/no/vegvesen/ixn/federation/qpid/QpidClientIT.java
+++ b/routing-configurer/src/test/java/no/vegvesen/ixn/federation/qpid/QpidClientIT.java
@@ -7,10 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -116,5 +113,27 @@ public class QpidClientIT {
 		//Delete the queue
 		client.removeQueue(crab.getName());
 		assertThat(client.queueExists(crab.getName())).isFalse();
+	}
+
+	@Test
+	public void addAnInterchangeToGroups(){
+		String newUser = "herring";
+		client.addInterchangeUserToGroups(newUser, "federated-interchanges");
+
+		List<String> userNames = client.getInterchangesUserNames("federated-interchanges");
+
+		assertThat(userNames.contains(newUser));
+	}
+
+	@Test
+	public void deleteAnInterchangeFromGroups(){
+		String deleteUser = "carp";
+		client.addInterchangeUserToGroups(deleteUser, "federated-interchanges");
+		List<String> userNames = client.getInterchangesUserNames("federated-interchanges");
+		assertThat(userNames.contains(deleteUser));
+
+		client.removeInterchangeUserFromGroups("federated-interchanges", deleteUser);
+		userNames = client.getInterchangesUserNames("federated-interchanges");
+		assertThat(!userNames.contains(deleteUser));
 	}
 }

--- a/routing-configurer/src/test/resources/qpid/groups
+++ b/routing-configurer/src/test/resources/qpid/groups
@@ -1,1 +1,4 @@
+#Written Wed Jun 26 13:51:23 GMT 2019
+#Wed Jun 26 13:51:23 GMT 2019
+federated-interchanges.users=herring
 administrators.users=qpid-admin,routing_configurer

--- a/routing-configurer/src/test/resources/qpid/groups
+++ b/routing-configurer/src/test/resources/qpid/groups
@@ -1,4 +1,2 @@
-#Written Wed Jun 26 13:51:23 GMT 2019
-#Wed Jun 26 13:51:23 GMT 2019
-federated-interchanges.users=herring
+federated-interchanges.users=
 administrators.users=qpid-admin,routing_configurer


### PR DESCRIPTION
Add neighbouring interchanges to the Qpid groups if they can provide interesting data
Remove neighbouring interchanges from Qpid groups if they reject our subscription request. 