### PR TITLE
Forward additional header values from original message

### DIFF
--- a/interchangenode/src/main/java/no/vegvesen/ixn/MessageProperties.java
+++ b/interchangenode/src/main/java/no/vegvesen/ixn/MessageProperties.java
@@ -1,5 +1,9 @@
 package no.vegvesen.ixn;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 public class MessageProperties {
 
     public final static String LAT = "lat";
@@ -10,4 +14,10 @@ public class MessageProperties {
     public final static String USERID = "JMSXUserID";
     public final static String HOW = "how";
     public final static String WHEN = "when";
+
+    private static Set<String> knownProperties = new LinkedHashSet<>(Arrays.asList(LAT, LON, WHAT, WHERE, WHO, USERID, HOW, WHEN));
+
+    public static boolean isKnownProperty(String propertyName) {
+        return knownProperties.contains(propertyName);
+    }
 }

--- a/interchangenode/src/main/java/no/vegvesen/ixn/messaging/IxnMessageProducer.java
+++ b/interchangenode/src/main/java/no/vegvesen/ixn/messaging/IxnMessageProducer.java
@@ -67,6 +67,11 @@ public class IxnMessageProducer {
 					if (message.getWhen() != null) {
 						outgoingMessage.setStringProperty(WHEN, message.getWhen());
 					}
+					for (String stringAttribute : message.getOtherStringAttributes().keySet()) {
+						String value = message.getOtherStringAttributes().get(stringAttribute);
+						logger.debug("Other string attribute {} value {}", stringAttribute, value);
+						outgoingMessage.setStringProperty(stringAttribute, value);
+					}
 					long expiration = message.getExpiration();
 					logger.debug("message expire time " + expiration);
 					outgoingMessage.setJMSExpiration(expiration);

--- a/interchangenode/src/main/java/no/vegvesen/ixn/model/IxnMessage.java
+++ b/interchangenode/src/main/java/no/vegvesen/ixn/model/IxnMessage.java
@@ -1,10 +1,10 @@
 package no.vegvesen.ixn.model;
 
+import no.vegvesen.ixn.MessageProperties;
+
 import javax.jms.JMSException;
 import javax.jms.TextMessage;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 import static no.vegvesen.ixn.MessageProperties.*;
 
@@ -21,6 +21,7 @@ public class IxnMessage {
     private List<String> countries = new ArrayList<>();
     private String how;
     private String when;
+    private Map<String, String> otherStringAttributes = new HashMap<>();
 
     public IxnMessage(TextMessage textMessage) throws JMSException {
         this(textMessage.getStringProperty(WHO),
@@ -37,6 +38,15 @@ public class IxnMessage {
         String when = textMessage.getStringProperty(WHEN);
         if (when != null) {
             this.when = when;
+        }
+
+        Enumeration propertyNames = textMessage.getPropertyNames();
+        while (propertyNames.hasMoreElements()) {
+            String propertyName = (String) propertyNames.nextElement();
+            String propertyValue = textMessage.getStringProperty(propertyName);
+            if (!MessageProperties.isKnownProperty(propertyName) && propertyValue != null) {
+                this.addOtherStringAttribute(propertyName, propertyValue);
+            }
         }
     }
 
@@ -115,5 +125,13 @@ public class IxnMessage {
 
     public String getWhen() {
         return when;
+    }
+
+    public Map<String, String> getOtherStringAttributes() {
+        return this.otherStringAttributes;
+    }
+
+    public void addOtherStringAttribute(String name, String value) {
+        this.otherStringAttributes.put(name, value);
     }
 }

--- a/interchangenode/src/test/java/no/vegvesen/ixn/messaging/InterchangeAppIT.java
+++ b/interchangenode/src/test/java/no/vegvesen/ixn/messaging/InterchangeAppIT.java
@@ -16,7 +16,7 @@ import java.util.Collections;
  * This test is run with profile "62" and uses ports in the 62...-series.
  * The amqp-url, username and password is specified in the application-62.properties.
  *
- * @See AccessControlIT uses separate user client connections.
+ * See AccessControlIT uses separate user client connections.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -42,6 +42,7 @@ public class InterchangeAppIT {
 				Collections.singletonList("traffic jam"),
 				"jam, jam - spam, spam");
 		message.setCountries(Collections.singletonList("no"));
+		message.addOtherStringAttribute("type", "Accident");
 		producer.sendMessage("onramp", message);
 		try {
 			Thread.sleep(2000);

--- a/interchangenode/src/test/java/no/vegvesen/ixn/messaging/TestIxnMessageConsumer.java
+++ b/interchangenode/src/test/java/no/vegvesen/ixn/messaging/TestIxnMessageConsumer.java
@@ -19,6 +19,7 @@ public class TestIxnMessageConsumer {
 		System.out.println("now         : " + now);
 		System.out.println("latency : " + (now - textMessage.getJMSDeliveryTime()));
 		System.out.println("where1: " + textMessage.getStringProperty("where1") );
+		System.out.println("type: " + textMessage.getStringProperty("type"));
 	}
 
 }

--- a/interchangenode/src/test/java/no/vegvesen/ixn/model/IxnMessageTest.java
+++ b/interchangenode/src/test/java/no/vegvesen/ixn/model/IxnMessageTest.java
@@ -3,8 +3,16 @@ package no.vegvesen.ixn.model;
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.jms.JMSException;
+import javax.jms.TextMessage;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+
+import static no.vegvesen.ixn.MessageProperties.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class IxnMessageTest {
 
@@ -29,9 +37,32 @@ public class IxnMessageTest {
     public void whatIsParsedCorrectly(){
         String situationString = "Obstruction, Works, Conditions";
         List<String> situations = Arrays.asList("Obstruction", "Works", "Conditions");
-
         Assert.assertEquals(situations, IxnMessage.parseWhat(situationString));
     }
 
+    @Test
+    public void constructFromTextMessageNoExtraHeaders() throws JMSException {
+        TextMessage mock = mock(TextMessage.class);
+        when(mock.getPropertyNames()).thenReturn(Collections.enumeration(Arrays.asList(WHAT, WHO, LAT, LON)));
+        when(mock.getStringProperty(WHAT)).thenReturn("Conditions");
+        when(mock.getStringProperty(WHO)).thenReturn("dr who");
+        when(mock.getDoubleProperty(LAT)).thenReturn(10.3d);
+        when(mock.getDoubleProperty(LON)).thenReturn(60.3d);
+        IxnMessage ixnMessage = new IxnMessage(mock);
+        assertThat(ixnMessage.getOtherStringAttributes()).isEmpty();
+    }
+
+    @Test
+    public void constructFromTextMessageGivesCorrectHeaders() throws JMSException {
+        TextMessage mock = mock(TextMessage.class);
+        when(mock.getPropertyNames()).thenReturn(Collections.enumeration(Arrays.asList(WHAT, WHO, LAT, LON, "type")));
+        when(mock.getStringProperty("type")).thenReturn("rec type");
+        when(mock.getStringProperty(WHAT)).thenReturn("Conditions");
+        when(mock.getStringProperty(WHO)).thenReturn("dr who");
+        when(mock.getDoubleProperty(LAT)).thenReturn(10.3d);
+        when(mock.getDoubleProperty(LON)).thenReturn(60.3d);
+        IxnMessage ixnMessage = new IxnMessage(mock);
+        assertThat(ixnMessage.getOtherStringAttributes()).containsKey("type");
+    }
 
 }


### PR DESCRIPTION
This change allows the traditional interchange node (not federated) to forward other message headers than the ones specified in the original client specification.