### PR TITLE
Pre test fix for neighbour disc

### DIFF
--- a/neighbour-discoverer/src/main/java/no/vegvesen/ixn/federation/discoverer/NeighbourDiscoverer.java
+++ b/neighbour-discoverer/src/main/java/no/vegvesen/ixn/federation/discoverer/NeighbourDiscoverer.java
@@ -367,17 +367,19 @@ public class NeighbourDiscoverer {
 		// If Self has updated Subscriptions since last time we posted a subscription request, we need to recalculate the subscription request for all neighbours.
 
 		logger.info("Checking if any Service Providers have updated their subscriptions...");
-		logger.info("Self name: {}", myName);
 
 		Self self = selfRepository.findByName(myName);
-		if(self == null || self.getLocalSubscriptions().isEmpty()){
+		if(self == null){
+
+			// || self.getLocalSubscriptions().isEmpty()
+			// TODO: if local subscriptions are empty, we have to check if we have any subscriptions to any neighbours that we need to tear down!! How to do this??
 			return; // We have nothing to post to our neighbour
 		}
 
 		DiscoveryState discoveryState = discoveryStateRepository.findByName(myName);
 
 		if(discoveryState == null || discoveryState.getLastSubscriptionRequest() == null || self.getLastUpdatedLocalSubscriptions().isAfter(discoveryState.getLastSubscriptionRequest())){
-			// Either first post or an upate.
+			// Either first post or an update.
 			// Local Subscriptions have been updated since last time performed the subscription request.
 			// Recalculate subscriptions to all neighbours - if any of them have changed, post a new subscription request.
 

--- a/neighbour-discoverer/src/main/java/no/vegvesen/ixn/federation/discoverer/NeighbourDiscoverer.java
+++ b/neighbour-discoverer/src/main/java/no/vegvesen/ixn/federation/discoverer/NeighbourDiscoverer.java
@@ -375,7 +375,7 @@ public class NeighbourDiscoverer {
 
 		DiscoveryState discoveryState = discoveryStateRepository.findByName(myName);
 
-		if(discoveryState == null || discoveryState.getLastSubscriptionRequest() == null || self.getLastUpdatedLocalSubscriptions().isAfter(discoveryState.getLastSubscriptionRequest())){
+		if(discoveryState == null || discoveryState.getLastSubscriptionRequest() == null || (self.getLastUpdatedLocalSubscriptions() != null && self.getLastUpdatedLocalSubscriptions().isAfter(discoveryState.getLastSubscriptionRequest()))){
 			// Either first post or an update.
 			// Local Subscriptions have been updated since last time performed the subscription request.
 			// Recalculate subscriptions to all neighbours - if any of them have changed, post a new subscription request.
@@ -487,7 +487,7 @@ public class NeighbourDiscoverer {
 
 		DiscoveryState discoveryState = discoveryStateRepository.findByName(myName);
 
-		if(discoveryState == null || discoveryState.getLastCapabilityExchange()==null || self.getLastUpdatedLocalCapabilities().isAfter(discoveryState.getLastCapabilityExchange())){
+		if(discoveryState == null || discoveryState.getLastCapabilityExchange()==null || (self.getLastUpdatedLocalCapabilities() != null && self.getLastUpdatedLocalCapabilities().isAfter(discoveryState.getLastCapabilityExchange()))){
 			// Capability post either not performed before, or Service Providers have been updated.
 			// Last updated capabilities is after last capability exchange - perform new capability exchange with all neighbours
 

--- a/neighbour-discoverer/src/main/java/no/vegvesen/ixn/federation/discoverer/NeighbourDiscoverer.java
+++ b/neighbour-discoverer/src/main/java/no/vegvesen/ixn/federation/discoverer/NeighbourDiscoverer.java
@@ -370,9 +370,6 @@ public class NeighbourDiscoverer {
 
 		Self self = selfRepository.findByName(myName);
 		if(self == null){
-
-			// || self.getLocalSubscriptions().isEmpty()
-			// TODO: if local subscriptions are empty, we have to check if we have any subscriptions to any neighbours that we need to tear down!! How to do this??
 			return; // We have nothing to post to our neighbour
 		}
 
@@ -483,7 +480,7 @@ public class NeighbourDiscoverer {
 		logger.info("Checking if any Service Providers have updated their capabilities...");
 
 		Self self = selfRepository.findByName(myName);
-		if(self == null || self.getLocalCapabilities().isEmpty()){
+		if(self == null){
 			logger.info("Self was null. Waiting for normal capability exchange to be performed first.");
 			return; // We have nothing to post to our neighbours.
 		}

--- a/onboard-server/src/main/java/no/vegvesen/ixn/serviceprovider/OnboardRestController.java
+++ b/onboard-server/src/main/java/no/vegvesen/ixn/serviceprovider/OnboardRestController.java
@@ -189,12 +189,15 @@ public class OnboardRestController {
 			self.setLastUpdatedLocalCapabilities(LocalDateTime.now());
 			self.setLocalCapabilities(updatedCapabilities);
 			selfRepository.save(self);
+			logger.info("Updated Self: {}", self.toString());
+			selfRepository.save(self);
 			return;
 		}
 		logger.info("Capabilities have not changed. Keeping the current representation of self.");
 	}
 
 	Set<DataType> calculateSelfCapabilities() {
+		logger.info("Calculating Self capabilities...");
 		Set<DataType> localCapabilities = new HashSet<>();
 		Iterable<ServiceProvider> serviceProviders = serviceProviderRepository.findAll();
 
@@ -204,8 +207,7 @@ public class OnboardRestController {
 			logger.info("Service Provider capabilities: {}", serviceProviderCapabilities.toString());
 			localCapabilities.addAll(serviceProviderCapabilities);
 		}
-
-		logger.info("!!! Calculated self capabilities: {}", localCapabilities);
+		logger.info("Calculated Self capabilities: {}", localCapabilities);
 		return localCapabilities;
 	}
 
@@ -219,25 +221,26 @@ public class OnboardRestController {
 			logger.info("Subscriptions have changed. Updating representation of self.");
 			self.setLocalSubscriptions(updatedSubscriptions);
 			self.setLastUpdatedLocalSubscriptions(LocalDateTime.now());
-			Self updatedSelf = selfRepository.save(self);
-			logger.info("Updated Self: {}", updatedSelf.toString());
+			selfRepository.save(self);
+			logger.info("Updated Self: {}", self.toString());
 			return;
 		}
-
 		logger.info("Subscriptions have not changed. Keeping the current representation of self.");
 	}
 
 	Set<Subscription> calculateSelfSubscriptions(){
-		Set<Subscription> selfSubscriptions = new HashSet<>();
+		logger.info("Calculating Self subscriptions...");
+		Set<Subscription> localSubscriptions = new HashSet<>();
 		Iterable<ServiceProvider> serviceProviders = serviceProviderRepository.findAll();
 
 		for (ServiceProvider serviceProvider : serviceProviders) {
+			logger.info("Service provider name: {}", serviceProvider.getName());
 			Set<Subscription> serviceProviderSubscriptions = serviceProvider.getSubscriptionRequest().getSubscriptions();
-
-			selfSubscriptions.addAll(serviceProviderSubscriptions);
+			logger.info("Service Provider Subscriptions: {}", serviceProviderSubscriptions.toString());
+			localSubscriptions.addAll(serviceProviderSubscriptions);
 		}
-		logger.info("Calculated Self subscriptions: {}", selfSubscriptions.toString());
-		return selfSubscriptions;
+		logger.info("Calculated Self subscriptions: {}", localSubscriptions.toString());
+		return localSubscriptions;
 	}
 
 	@RequestMapping(method = RequestMethod.POST, path = SUBSCRIPTION_PATH)

--- a/onboard-server/src/main/java/no/vegvesen/ixn/serviceprovider/OnboardRestController.java
+++ b/onboard-server/src/main/java/no/vegvesen/ixn/serviceprovider/OnboardRestController.java
@@ -344,9 +344,11 @@ public class OnboardRestController {
 
 		if(currentServiceProviderSubscriptions.isEmpty()){
 			// Subscription is now empty, notify Routing Configurer to tear down the queue.
+			logger.info("Service Provider subscriptions are now empty. Setting status to TEAR_DOWN.");
 			serviceProviderToUpdate.getSubscriptionRequest().setStatus(SubscriptionRequest.SubscriptionRequestStatus.TEAR_DOWN);
 		}else{
 			// Flip status to REQUESTED to notify Routing Configurer to change the queue filter.
+			logger.info("Service Provider subscriptions were updated, but are not empty. Setting status to REQUESTED");
 			serviceProviderToUpdate.getSubscriptionRequest().setStatus(SubscriptionRequest.SubscriptionRequestStatus.REQUESTED);
 		}
 


### PR DESCRIPTION
This is a fix for the bug that the Neighbour Discoverer did not post empty capabilities or subscription requests if the last local capability or subscription was removed. 

If the local capabilities or subscriptions have not been updated, we don't post anything.
