### PR TITLE
Neighbour server logging

### DIFF
--- a/helm/interchange/templates/haproxy-service.yml
+++ b/helm/interchange/templates/haproxy-service.yml
@@ -26,3 +26,6 @@ spec:
   - name: onboard
     port: {{ .Values.self.service_provider_port }}
     targetPort: onboard
+  {{- if .Values.self.static_external_ip }}
+  loadBalancerIP: {{ .Values.self.static_external_ip }}
+  {{- end -}}

--- a/neighbour-discoverer/src/main/resources/application.properties
+++ b/neighbour-discoverer/src/main/resources/application.properties
@@ -20,6 +20,7 @@ spring.jpa.hibernate.ddl-auto = update
 logging.pattern.console=%d{yyyy-MM-dd} %d{HH:mm:ss}  [%-12.12thread]  %highlight(%-5level)  %-30.30logger{30}  %-42method  [%X{local_interchange}  %X{remote_interchange}]  - %msg %ex{full}%n
 logging.level.org.hibernate.SQL=warn
 logging.level.root=info
+logging.level.no=debug
 spring.output.ansi.enabled=ALWAYS
 
 

--- a/neighbour-dns/src/main/java/no/vegvesen/ixn/federation/discoverer/DNSFacade.java
+++ b/neighbour-dns/src/main/java/no/vegvesen/ixn/federation/discoverer/DNSFacade.java
@@ -85,4 +85,7 @@ public class DNSFacade {
 		return srvPorts;
 	}
 
+	public String getDnsServerName() {
+		return this.dnsProperties.getDomainName();
+	}
 }

--- a/neighbour-dns/src/main/java/no/vegvesen/ixn/federation/discoverer/DNSFacade.java
+++ b/neighbour-dns/src/main/java/no/vegvesen/ixn/federation/discoverer/DNSFacade.java
@@ -38,14 +38,16 @@ public class DNSFacade {
 				neighbour.setMessageChannelPort(messageChannelPorts.get(nodeName));
 				if (controlChannelPorts.containsKey(nodeName)) {
 					neighbour.setControlChannelPort(controlChannelPorts.get(nodeName));
-					logger.debug("DNS server has message channel port {} and control channel port {} for node {}",
+					logger.debug("DNS server {} has message channel port {} and control channel port {} for node {}",
+							getDnsServerName(),
 							neighbour.getMessageChannelPort(),
 							neighbour.getControlChannelPort(),
 							neighbour.getName());
 				}
 				else {
 					neighbour.setControlChannelPort(dnsProperties.getControlChannelPort());
-					logger.debug("DNS server has only message channel port {} for node, using standard port for control channel {} for node {}",
+					logger.debug("DNS server {} has only message channel port {} for node, using standard port for control channel {} for node {}",
+							getDnsServerName(),
 							neighbour.getMessageChannelPort(),
 							neighbour.getControlChannelPort(),
 							neighbour.getName());
@@ -53,13 +55,12 @@ public class DNSFacade {
 				neighbours.add(neighbour);
 				ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();
 				String json = ow.writeValueAsString(neighbour);
-				logger.debug("DNS lookup gave Neighbour: \n" + json);
-
+				logger.debug("DNS lookup in {} gave Neighbour {}", getDnsServerName(), json);
 			}
 			return neighbours;
 
 		} catch (Exception e) {
-			logger.error("Error in DNSFacade", e);
+			logger.error(String.format("Error in DNSFacade %s", getDnsServerName()), e);
 		}
 		return Collections.emptyList();
 	}
@@ -72,7 +73,8 @@ public class DNSFacade {
 		Record[] records = new Lookup(srvLookupString, Type.SRV).run();
 
 		if (records == null) {
-			throw new RuntimeException("DNS lookup failed. Returned SRV records for " + srvLookupString + " was null.");
+			throw new RuntimeException(String.format("DNS lookup in %s failed. Returned SRV records for %s was null.",
+					getDnsServerName(), srvLookupString));
 		}
 
 		for (Record record : records) {


### PR DESCRIPTION
Assign static ip addresses reserved in the google cloud for incoming requests on the ha-proxy.

Log dns result on incoming requests to the neighbour server.