### PR TITLE
Interchange not found

### DIFF
--- a/neighbour-model/src/main/java/no/vegvesen/ixn/federation/exceptions/InterchangeNotInDNSException.java
+++ b/neighbour-model/src/main/java/no/vegvesen/ixn/federation/exceptions/InterchangeNotInDNSException.java
@@ -1,0 +1,8 @@
+package no.vegvesen.ixn.federation.exceptions;
+
+public class InterchangeNotInDNSException extends RuntimeException{
+
+	public InterchangeNotInDNSException(String message) {
+		super(message);
+	}
+}

--- a/neighbour-server/src/main/java/no/vegvesen/ixn/federation/server/NeighbourRestController.java
+++ b/neighbour-server/src/main/java/no/vegvesen/ixn/federation/server/NeighbourRestController.java
@@ -222,7 +222,7 @@ public class NeighbourRestController {
 
 			return subscriptionTransformer.subscriptionToSubscriptionApi(subscription);
 		} else {
-			throw new InterchangeNotFoundException("The requested Neighbour does not exist.");
+			throw new InterchangeNotFoundException("The requested Neighbour is not known to this interchange node.");
 		}
 	}
 
@@ -286,7 +286,7 @@ public class NeighbourRestController {
 			neighbour.setControlChannelPort(dnsNeighbour.getControlChannelPort());
 			neighbour.setMessageChannelPort(dnsNeighbour.getMessageChannelPort());
 		} else {
-			throw new InterchangeNotFoundException(
+			throw new InterchangeNotInDNSException(
 					String.format("Received capability post from neighbour %s, but could not find in DNS %s",
 							neighbour.getName(),
 							dnsFacade.getDnsServerName()));

--- a/neighbour-server/src/main/java/no/vegvesen/ixn/federation/server/NeighbourRestController.java
+++ b/neighbour-server/src/main/java/no/vegvesen/ixn/federation/server/NeighbourRestController.java
@@ -286,7 +286,7 @@ public class NeighbourRestController {
 			neighbour.setControlChannelPort(dnsNeighbour.getControlChannelPort());
 			neighbour.setMessageChannelPort(dnsNeighbour.getMessageChannelPort());
 		} else {
-			throw new DiscoveryException(
+			throw new InterchangeNotFoundException(
 					String.format("Received capability post from neighbour %s, but could not find in DNS %s",
 							neighbour.getName(),
 							dnsFacade.getDnsServerName()));

--- a/neighbour-server/src/main/java/no/vegvesen/ixn/federation/server/NeighbourServiceErrorAdvice.java
+++ b/neighbour-server/src/main/java/no/vegvesen/ixn/federation/server/NeighbourServiceErrorAdvice.java
@@ -29,6 +29,11 @@ public class NeighbourServiceErrorAdvice {
 		return error(NOT_FOUND, e);
 	}
 
+	@ExceptionHandler({InterchangeNotInDNSException.class})
+	public ResponseEntity<ErrorDetails> interchangeNotInDNSException(InterchangeNotInDNSException e){
+		return error(BAD_REQUEST, e);
+	}
+
 	@ExceptionHandler({SubscriptionNotFoundException.class})
 	public ResponseEntity<ErrorDetails> subscriptionNotFoundException(SubscriptionNotFoundException e){
 		return error(NOT_FOUND, e);

--- a/neighbour-server/src/test/java/no/vegvesen/ixn/federation/server/NeighbourRestControllerTest.java
+++ b/neighbour-server/src/test/java/no/vegvesen/ixn/federation/server/NeighbourRestControllerTest.java
@@ -4,18 +4,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import no.vegvesen.ixn.federation.api.v1_0.*;
 import no.vegvesen.ixn.federation.discoverer.DNSFacade;
 import no.vegvesen.ixn.federation.exceptions.CNAndApiObjectMismatchException;
-import no.vegvesen.ixn.federation.exceptions.DiscoveryException;
+import no.vegvesen.ixn.federation.exceptions.InterchangeNotFoundException;
 import no.vegvesen.ixn.federation.model.*;
 import no.vegvesen.ixn.federation.repository.NeighbourRepository;
 import no.vegvesen.ixn.federation.repository.SelfRepository;
-import no.vegvesen.ixn.federation.repository.ServiceProviderRepository;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -114,7 +111,7 @@ public class NeighbourRestControllerTest {
 
 	@Test
 	public void postingCapabilitiesUnknownInDNSReturnsError() throws Exception {
-		expectedException.expectCause(isA(DiscoveryException.class));
+		expectedException.expectCause(isA(InterchangeNotFoundException.class));
 
 		// Mocking the incoming certificate
 		mockCertificate("unknownNeighbour");

--- a/neighbour-server/src/test/java/no/vegvesen/ixn/federation/server/NeighbourRestControllerTest.java
+++ b/neighbour-server/src/test/java/no/vegvesen/ixn/federation/server/NeighbourRestControllerTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import no.vegvesen.ixn.federation.api.v1_0.*;
 import no.vegvesen.ixn.federation.discoverer.DNSFacade;
 import no.vegvesen.ixn.federation.exceptions.CNAndApiObjectMismatchException;
-import no.vegvesen.ixn.federation.exceptions.InterchangeNotFoundException;
+import no.vegvesen.ixn.federation.exceptions.InterchangeNotInDNSException;
 import no.vegvesen.ixn.federation.model.*;
 import no.vegvesen.ixn.federation.repository.NeighbourRepository;
 import no.vegvesen.ixn.federation.repository.SelfRepository;
@@ -111,7 +111,7 @@ public class NeighbourRestControllerTest {
 
 	@Test
 	public void postingCapabilitiesUnknownInDNSReturnsError() throws Exception {
-		expectedException.expectCause(isA(InterchangeNotFoundException.class));
+		expectedException.expectCause(isA(InterchangeNotInDNSException.class));
 
 		// Mocking the incoming certificate
 		mockCertificate("unknownNeighbour");

--- a/one-node.yml
+++ b/one-node.yml
@@ -12,7 +12,7 @@ services:
       - POSTGRES_DB=federation
 
   local_onboard_server:
-    image: eu.gcr.io/nordic-way-aad182cc/onboard-server:federation-master
+    image: eu.gcr.io/nordic-way-aad182cc/onboard-server:federation-nw2
     container_name: local_onboard_server
     depends_on:
       - local_db
@@ -32,7 +32,7 @@ services:
 
 
   local_interchange_app:
-    image: eu.gcr.io/nordic-way-aad182cc/interchangenode:federation-master
+    image: eu.gcr.io/nordic-way-aad182cc/interchangenode:federation-nw2
     container_name: local_interchange_app
     hostname: local_interchange_app
     links:
@@ -47,7 +47,7 @@ services:
 
 
   local_postgis:
-    image: eu.gcr.io/nordic-way-aad182cc/postgis:federation-master
+    image: eu.gcr.io/nordic-way-aad182cc/postgis:federation-nw2
     environment:
     - POSTGRES_USER=geolookup
     - POSTGRES_PASSWORD=geolookup
@@ -85,12 +85,12 @@ services:
       - PASSWD_FILE=/config/passwd
 
   local_neighbour_server:
-    image: eu.gcr.io/nordic-way-aad182cc/neighbour-server:federation-master
+    image: eu.gcr.io/nordic-way-aad182cc/neighbour-server:federation-nw2
     container_name: local_neighbour_server
     depends_on:
       - local_db
     ports:
-      - 8090
+      - 32443:8090
     volumes:
       - "./tmp:/jks"
     environment:
@@ -104,7 +104,7 @@ services:
       - KEY_STORE_PASSWORD=password
 
   local_routing_configurer:
-    image: eu.gcr.io/nordic-way-aad182cc/routing-configurer:federation-master
+    image: eu.gcr.io/nordic-way-aad182cc/routing-configurer:federation-nw2
     container_name: local_routing_configurer
     depends_on:
       - local_db
@@ -123,7 +123,7 @@ services:
       - KEY_PASSWORD=password
 
   local_neighbour_discoverer:
-    image: eu.gcr.io/nordic-way-aad182cc/neighbour-discoverer:federation-master
+    image: eu.gcr.io/nordic-way-aad182cc/neighbour-discoverer:federation-nw2
     container_name: local_neighbour_discoverer
     depends_on:
       - local_db
@@ -141,7 +141,7 @@ services:
       - KEY_PASSWORD=password
 
   local_message_forwarder_app:
-    image: eu.gcr.io/nordic-way-aad182cc/message-forwarder:federation-master
+    image: eu.gcr.io/nordic-way-aad182cc/message-forwarder:federation-nw2
     container_name: local_message_forwarder_app
     depends_on:
     - local_db

--- a/one-node.yml
+++ b/one-node.yml
@@ -68,7 +68,7 @@ services:
     ports:
       - 8666:8080
       - 443
-      - 63002:5671
+      - 5671:5671
       - 5672
     volumes:
       - "./qpid/local:/config"
@@ -90,7 +90,7 @@ services:
     depends_on:
       - local_db
     ports:
-      - 32443:8090
+      - 443:8090
     volumes:
       - "./tmp:/jks"
     environment:

--- a/one-node.yml
+++ b/one-node.yml
@@ -63,7 +63,7 @@ services:
     - 6677:5432
 
   local_qpid:
-    image: eu.gcr.io/nordic-way-aad182cc/qpid:federation-master
+    image: eu.gcr.io/nordic-way-aad182cc/qpid:federation-nw2
     container_name: local_qpid
     ports:
       - 8666:8080


### PR DESCRIPTION
Neighbour server returns a 400-series http error code (indicating a client error) when posting capability that is from a server not registered in the DNS. Before this, the server returned a 500 error code indicating an _internal_ error.

Besides that the one-node.yml exposes default ports for amqps from qpid and https from neighbour server.
Also tag names to be used in one-node.yml points to latest of the branch. 