### PR TITLE
Message forward reverse no federated group

### DIFF
--- a/diagrams/message_collector.txt
+++ b/diagrams/message_collector.txt
@@ -1,5 +1,5 @@
 @startuml
-skinparam sequenceMessageAlign center
+skinparam sequenceMessage Align center
 
 box "<size:22>Interchange A</size>" #LightGrey
 database "broker" as client_broker
@@ -9,11 +9,17 @@ Actor "Message\nCollector" as C
 end box
 
 box "<size:22>Interchange B</size>" #LightBlue
+
+
 queue A
+queue nwEx
 database "message \nbroker" as server_broker
+activate nwEx
+nwEx -> A: A subscription
+activate A
 end box
 
-C -> client_db: Get all neighbours with // subscriptionRequest Status FEDERATED_ACCESS_GRANTED
+C -> client_db: Get all neighbours with \n SubscriptionRequestStatus ESTABLISHED
 C <-- client_db: Interchange B
 
 activate C

--- a/helm/interchange/templates/qpid-config.yml
+++ b/helm/interchange/templates/qpid-config.yml
@@ -189,15 +189,6 @@ data:
               }
             },
             {
-              "objectType" : "EXCHANGE",
-              "identity" : "federated-interchanges",
-              "operation" : "PUBLISH",
-              "outcome" : "ALLOW_LOG",
-              "attributes" : {
-                "NAME" : "fedEx"
-              }
-            },
-            {
               "objectType": "VIRTUALHOST",
               "identity": "federated-interchanges",
               "operation": "ACCESS",

--- a/message-collector/src/main/java/no/vegvesen/ixn/federation/messagecollector/NeighbourFetcher.java
+++ b/message-collector/src/main/java/no/vegvesen/ixn/federation/messagecollector/NeighbourFetcher.java
@@ -20,7 +20,6 @@ public class NeighbourFetcher {
     }
 
     public List<Neighbour> listNeighboursToConsumeFrom() {
-        List<Neighbour> neighbours = repository.findByFedIn_StatusIn(SubscriptionRequestStatus.FEDERATED_ACCESS_GRANTED);
-        return neighbours;
+		return repository.findByFedIn_StatusIn(SubscriptionRequestStatus.ESTABLISHED);
     }
 }

--- a/message-collector/src/main/resources/application.properties
+++ b/message-collector/src/main/resources/application.properties
@@ -25,3 +25,4 @@ collector.truststorepassword=password
 collector.truststoretype=JKS
 collector.writequeue=fedEx
 
+collector.fixeddelay=30000

--- a/message-collector/src/test/java/no/vegvesen/ixn/federation/messagecollector/MessageCollectorOldIT.java
+++ b/message-collector/src/test/java/no/vegvesen/ixn/federation/messagecollector/MessageCollectorOldIT.java
@@ -92,7 +92,9 @@ public class MessageCollectorOldIT extends DockerBaseIT {
 
 		logger.debug("Recreating the message queue");
 		when(remoteNeighbour.getSubscriptionRequest()).thenReturn(new SubscriptionRequest(SubscriptionRequestStatus.EMPTY, Collections.emptySet()));
-		qpidClient.setupRouting(remoteNeighbour, "nwEx");
+		qpidClient.createQueue(remoteNeighbour.getName());
+		qpidClient.addReadAccess(remoteNeighbour.getName(), remoteNeighbour.getName());
+		qpidClient.addInterchangeUserToGroups(remoteNeighbour.getName(), QpidClient.FEDERATED_GROUP_NAME);
 
 		when(fetcher.listNeighboursToConsumeFrom()).thenReturn(Collections.singletonList(remoteNeighbour));
 		messageForwarder.runSchedule();

--- a/message-collector/src/test/java/no/vegvesen/ixn/federation/messagecollector/MessageCollectorOldIT.java
+++ b/message-collector/src/test/java/no/vegvesen/ixn/federation/messagecollector/MessageCollectorOldIT.java
@@ -94,7 +94,7 @@ public class MessageCollectorOldIT extends DockerBaseIT {
 		when(remoteNeighbour.getSubscriptionRequest()).thenReturn(new SubscriptionRequest(SubscriptionRequestStatus.EMPTY, Collections.emptySet()));
 		qpidClient.createQueue(remoteNeighbour.getName());
 		qpidClient.addReadAccess(remoteNeighbour.getName(), remoteNeighbour.getName());
-		qpidClient.addInterchangeUserToGroups(remoteNeighbour.getName(), QpidClient.FEDERATED_GROUP_NAME);
+		qpidClient.addMemberToGroup(remoteNeighbour.getName(), QpidClient.FEDERATED_GROUP_NAME);
 
 		when(fetcher.listNeighboursToConsumeFrom()).thenReturn(Collections.singletonList(remoteNeighbour));
 		messageForwarder.runSchedule();

--- a/message-collector/src/test/resources/docker/localhost/vhost.json
+++ b/message-collector/src/test/resources/docker/localhost/vhost.json
@@ -97,15 +97,6 @@
           }
         },
         {
-          "objectType": "EXCHANGE",
-          "identity": "federated-interchanges",
-          "operation": "PUBLISH",
-          "outcome": "ALLOW_LOG",
-          "attributes": {
-            "NAME": "fedEx"
-          }
-        },
-        {
           "objectType": "QUEUE",
           "identity": "interchange",
           "operation": "CONSUME",

--- a/message-collector/src/test/resources/docker/remote/vhost.json
+++ b/message-collector/src/test/resources/docker/remote/vhost.json
@@ -104,15 +104,6 @@
           }
         },
         {
-          "objectType": "EXCHANGE",
-          "identity": "federated-interchanges",
-          "operation": "PUBLISH",
-          "outcome": "ALLOW_LOG",
-          "attributes": {
-            "NAME": "fedEx"
-          }
-        },
-        {
           "objectType": "QUEUE",
           "identity": "interchange",
           "operation": "CONSUME",

--- a/neighbour-model/src/main/java/no/vegvesen/ixn/federation/model/Subscriber.java
+++ b/neighbour-model/src/main/java/no/vegvesen/ixn/federation/model/Subscriber.java
@@ -1,9 +1,29 @@
 package no.vegvesen.ixn.federation.model;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public interface Subscriber {
 	String getName();
 
 	SubscriptionRequest getSubscriptionRequest();
 
 	void setSubscriptionRequestStatus(SubscriptionRequestStatus subscriptionRequestStatus);
+
+	default Set<String> getUnwantedBindKeys(Set<String> existingBindKeys) {
+		Set<String> wantedBindKeys = this.wantedBindings();
+		Set<String> unwantedBindKeys = new HashSet<>(existingBindKeys);
+		unwantedBindKeys.removeAll(wantedBindKeys);
+		return unwantedBindKeys;
+	}
+
+	default Set<String> wantedBindings() {
+		Set<String> wantedBindings = new HashSet<>();
+		for (Subscription subscription : getSubscriptionRequest().getSubscriptions()) {
+			wantedBindings.add(subscription.bindKey());
+		}
+		return wantedBindings;
+	}
+
+
 }

--- a/neighbour-model/src/main/java/no/vegvesen/ixn/federation/model/Subscription.java
+++ b/neighbour-model/src/main/java/no/vegvesen/ixn/federation/model/Subscription.java
@@ -93,4 +93,8 @@ public class Subscription {
 				", path='" + path + '\'' +
 				'}';
 	}
+
+	public String bindKey() {
+		return "" + selector.hashCode();
+	}
 }

--- a/neighbour-model/src/main/java/no/vegvesen/ixn/federation/model/SubscriptionRequestStatus.java
+++ b/neighbour-model/src/main/java/no/vegvesen/ixn/federation/model/SubscriptionRequestStatus.java
@@ -1,3 +1,3 @@
 package no.vegvesen.ixn.federation.model;
 
-public enum SubscriptionRequestStatus {REQUESTED, ESTABLISHED, NO_OVERLAP, TEAR_DOWN, EMPTY, FAILED, UNREACHABLE, REJECTED, FEDERATED_ACCESS_GRANTED}
+public enum SubscriptionRequestStatus {REQUESTED, ESTABLISHED, NO_OVERLAP, TEAR_DOWN, EMPTY, FAILED, UNREACHABLE, REJECTED}

--- a/neighbour-model/src/main/java/no/vegvesen/ixn/federation/model/SubscriptionRequestStatus.java
+++ b/neighbour-model/src/main/java/no/vegvesen/ixn/federation/model/SubscriptionRequestStatus.java
@@ -1,3 +1,3 @@
 package no.vegvesen.ixn.federation.model;
 
-public enum SubscriptionRequestStatus {REQUESTED, ESTABLISHED, NO_OVERLAP, TEAR_DOWN, EMPTY, FAILED, UNREACHABLE, REJECTED}
+public enum SubscriptionRequestStatus {REQUESTED, ESTABLISHED, NO_OVERLAP, TEAR_DOWN, EMPTY, FAILED, UNREACHABLE, REJECTED, FEDERATED_ACCESS_GRANTED}

--- a/qpid/local/vhost.json
+++ b/qpid/local/vhost.json
@@ -83,15 +83,6 @@
           }
         },
         {
-          "objectType": "EXCHANGE",
-          "identity": "federated-interchanges",
-          "operation": "PUBLISH",
-          "outcome": "ALLOW_LOG",
-          "attributes": {
-            "NAME": "fedEx"
-          }
-        },
-        {
           "objectType": "QUEUE",
           "identity": "interchange",
           "operation": "CONSUME",

--- a/qpid/remote/vhost.json
+++ b/qpid/remote/vhost.json
@@ -83,15 +83,6 @@
           }
         },
         {
-          "objectType": "EXCHANGE",
-          "identity": "federated-interchanges",
-          "operation": "PUBLISH",
-          "outcome": "ALLOW_LOG",
-          "attributes": {
-            "NAME": "fedEx"
-          }
-        },
-        {
           "objectType": "QUEUE",
           "identity": "king_gustaf.itsinterchange.eu",
           "operation": "CONSUME",

--- a/routing-configurer/src/main/java/no/vegvesen/ixn/federation/RoutingConfigurer.java
+++ b/routing-configurer/src/main/java/no/vegvesen/ixn/federation/RoutingConfigurer.java
@@ -57,10 +57,10 @@ public class RoutingConfigurer {
 			logger.debug("Removing routing for subscriber {}", subscriber.getName());
 			qpidClient.removeQueue(subscriber.getName());
 			if (subscriber instanceof ServiceProvider) {
-				removeUserFromGroup(SERVICE_PROVIDERS_GROUP_NAME, subscriber);
+				removeSubscriberFromGroup(SERVICE_PROVIDERS_GROUP_NAME, subscriber);
 			}
 			else if (subscriber instanceof Neighbour){
-				removeUserFromGroup(FEDERATED_GROUP_NAME, subscriber);
+				removeSubscriberFromGroup(FEDERATED_GROUP_NAME, subscriber);
 			}
 			logger.info("Removed routing for subscriber {}", subscriber.getName());
 			subscriber.setSubscriptionRequestStatus(SubscriptionRequestStatus.EMPTY);
@@ -138,23 +138,23 @@ public class RoutingConfigurer {
 	}
 
 	private void addSubscriberToGroup(String groupName, Subscriber subscriber) {
-		List<String> existingGroupMembers = qpidClient.getInterchangesUserNames(groupName);
+		List<String> existingGroupMembers = qpidClient.getGroupMemberNames(groupName);
 		logger.debug("Attempting to add subscriber {} to the group {}", subscriber.getName(), groupName);
 		logger.debug("Group {} contains the following members: {}", groupName, Arrays.toString(existingGroupMembers.toArray()));
 		if (!existingGroupMembers.contains(subscriber.getName())) {
 			logger.debug("Subscriber {} did not exist in the group {}. Adding...", subscriber, groupName);
-			qpidClient.addInterchangeUserToGroups(subscriber.getName(), groupName);
+			qpidClient.addMemberToGroup(subscriber.getName(), groupName);
 			logger.info("Added subscriber {} to Qpid group {}", subscriber.getName(), groupName);
 		} else {
 			logger.warn("Subscriber {} already exists in the group {}", subscriber.getName(), groupName);
 		}
 	}
 
-	private void removeUserFromGroup(String groupName, Subscriber subscriber) {
-		List<String> userNames = qpidClient.getInterchangesUserNames(groupName);
-		if (userNames.contains(subscriber.getName())) {
+	private void removeSubscriberFromGroup(String groupName, Subscriber subscriber) {
+		List<String> existingGroupMembers = qpidClient.getGroupMemberNames(groupName);
+		if (existingGroupMembers.contains(subscriber.getName())) {
 			logger.debug("Subscriber {} found in the groups {} Removing...", subscriber.getName(), groupName);
-			qpidClient.removeInterchangeUserFromGroups(groupName, subscriber.getName());
+			qpidClient.removeMemberFromGroup(groupName, subscriber.getName());
 			logger.info("Removed subscriber {} from Qpid group {}", subscriber.getName(), groupName);
 		} else {
 			logger.warn("Subscriber {} does not exist in the group {} and cannot be removed.", subscriber.getName(), groupName);

--- a/routing-configurer/src/main/java/no/vegvesen/ixn/federation/RoutingConfigurer.java
+++ b/routing-configurer/src/main/java/no/vegvesen/ixn/federation/RoutingConfigurer.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 import java.util.Arrays;
 import java.util.List;
 
-import static no.vegvesen.ixn.federation.qpid.QpidClient.FEDERATED_GROUP_NAME;
 import static no.vegvesen.ixn.federation.qpid.QpidClient.SERVICE_PROVIDERS_GROUP_NAME;
 
 @Component
@@ -101,18 +100,6 @@ public class RoutingConfigurer {
 		}
 	}
 
-	@Scheduled(fixedRateString = "${routing-configurer.groups-interval.add}")
-	private void setupUserInFederationGroup() {
-		logger.debug("Looking for users with fedIn ESTABLISHED to add to Qpid groups.");
-		List<Neighbour> neighboursToAddToGroups = neighbourRepository.findByFedIn_StatusIn(SubscriptionRequestStatus.ESTABLISHED);
-		logger.debug("Found {} users to add to Qpid group {}", neighboursToAddToGroups, FEDERATED_GROUP_NAME);
-
-		for (Neighbour neighbour : neighboursToAddToGroups) {
-			addSubscriberToGroup(FEDERATED_GROUP_NAME, neighbour);
-			neighbour.getFedIn().setStatus(SubscriptionRequestStatus.FEDERATED_ACCESS_GRANTED);
-			neighbourRepository.save(neighbour);
-		}
-	}
 
 	private void addSubscriberToGroup(String groupName, Subscriber subscriber) {
 		List<String> existingGroupMembers = qpidClient.getInterchangesUserNames(groupName);

--- a/routing-configurer/src/main/java/no/vegvesen/ixn/federation/RoutingConfigurer.java
+++ b/routing-configurer/src/main/java/no/vegvesen/ixn/federation/RoutingConfigurer.java
@@ -154,7 +154,7 @@ public class RoutingConfigurer {
 		List<String> existingGroupMembers = qpidClient.getGroupMemberNames(groupName);
 		if (existingGroupMembers.contains(subscriber.getName())) {
 			logger.debug("Subscriber {} found in the groups {} Removing...", subscriber.getName(), groupName);
-			qpidClient.removeMemberFromGroup(groupName, subscriber.getName());
+			qpidClient.removeMemberFromGroup(subscriber.getName(), groupName);
 			logger.info("Removed subscriber {} from Qpid group {}", subscriber.getName(), groupName);
 		} else {
 			logger.warn("Subscriber {} does not exist in the group {} and cannot be removed.", subscriber.getName(), groupName);

--- a/routing-configurer/src/main/java/no/vegvesen/ixn/federation/RoutingConfigurer.java
+++ b/routing-configurer/src/main/java/no/vegvesen/ixn/federation/RoutingConfigurer.java
@@ -53,6 +53,9 @@ public class RoutingConfigurer {
 				if (subscriber instanceof ServiceProvider) {
 					removeUserFromGroup(SERVICE_PROVIDERS_GROUP_NAME, subscriber);
 				}
+				else if (subscriber instanceof Neighbour){
+					removeUserFromGroup(FEDERATED_GROUP_NAME, subscriber);
+				}
 				logger.info("Removed routing for subscriber {}", subscriber.getName());
 				subscriber.setSubscriptionRequestStatus(SubscriptionRequestStatus.EMPTY);
 				saveSubscriber(subscriber);

--- a/routing-configurer/src/main/java/no/vegvesen/ixn/federation/RoutingConfigurer.java
+++ b/routing-configurer/src/main/java/no/vegvesen/ixn/federation/RoutingConfigurer.java
@@ -48,22 +48,26 @@ public class RoutingConfigurer {
 
 	void tearDownRouting(List<? extends Subscriber> readyToTearDownRouting) {
 		for (Subscriber subscriber : readyToTearDownRouting) {
-			try {
-				logger.debug("Removing routing for subscriber {}", subscriber.getName());
-				qpidClient.removeQueue(subscriber.getName());
-				if (subscriber instanceof ServiceProvider) {
-					removeUserFromGroup(SERVICE_PROVIDERS_GROUP_NAME, subscriber);
-				}
-				else if (subscriber instanceof Neighbour){
-					removeUserFromGroup(FEDERATED_GROUP_NAME, subscriber);
-				}
-				logger.info("Removed routing for subscriber {}", subscriber.getName());
-				subscriber.setSubscriptionRequestStatus(SubscriptionRequestStatus.EMPTY);
-				saveSubscriber(subscriber);
-				logger.debug("Saved subscriber {} with subscription request status EMPTY", subscriber.getName());
-			} catch (Exception e) {
-				logger.error("Could not remove routing for subscriber {}", subscriber.getName(), e);
+			tearDownSubscriberRouting(subscriber);
+		}
+	}
+
+	void tearDownSubscriberRouting(Subscriber subscriber) {
+		try {
+			logger.debug("Removing routing for subscriber {}", subscriber.getName());
+			qpidClient.removeQueue(subscriber.getName());
+			if (subscriber instanceof ServiceProvider) {
+				removeUserFromGroup(SERVICE_PROVIDERS_GROUP_NAME, subscriber);
 			}
+			else if (subscriber instanceof Neighbour){
+				removeUserFromGroup(FEDERATED_GROUP_NAME, subscriber);
+			}
+			logger.info("Removed routing for subscriber {}", subscriber.getName());
+			subscriber.setSubscriptionRequestStatus(SubscriptionRequestStatus.EMPTY);
+			saveSubscriber(subscriber);
+			logger.debug("Saved subscriber {} with subscription request status EMPTY", subscriber.getName());
+		} catch (Exception e) {
+			logger.error("Could not remove routing for subscriber {}", subscriber.getName(), e);
 		}
 	}
 

--- a/routing-configurer/src/main/java/no/vegvesen/ixn/federation/RoutingConfigurer.java
+++ b/routing-configurer/src/main/java/no/vegvesen/ixn/federation/RoutingConfigurer.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 import java.util.Arrays;
 import java.util.List;
 
+import static no.vegvesen.ixn.federation.qpid.QpidClient.FEDERATED_GROUP_NAME;
 import static no.vegvesen.ixn.federation.qpid.QpidClient.SERVICE_PROVIDERS_GROUP_NAME;
 
 @Component
@@ -88,6 +89,7 @@ public class RoutingConfigurer {
 					addSubscriberToGroup(SERVICE_PROVIDERS_GROUP_NAME, subscriber);
 				}
 				else if (subscriber instanceof Neighbour) {
+					addSubscriberToGroup(FEDERATED_GROUP_NAME, subscriber);
 					((Neighbour)subscriber).setSubscriptionRequest(setUpSubscriptionRequest);
 				}
 				logger.info("Routing set up for subscriber {}", subscriber.getName());
@@ -111,21 +113,6 @@ public class RoutingConfigurer {
 			logger.info("Added subscriber {} to Qpid group {}", subscriber.getName(), groupName);
 		} else {
 			logger.warn("Subscriber {} already exists in the group {}", subscriber.getName(), groupName);
-		}
-	}
-
-	@Scheduled(fixedRateString = "${routing-configurer.groups-interval.remove}")
-	private void removeNeighbourFromGroups() {
-		logger.debug("Looking for neighbours with rejected fedIn to remove from Qpid groups.");
-		String groupName = "federated-interchanges";
-		List<Neighbour> neighboursToRemoveFromGroups = neighbourRepository.findByFedIn_StatusIn(
-				SubscriptionRequestStatus.REJECTED);
-
-		if (!neighboursToRemoveFromGroups.isEmpty()) {
-			for (Neighbour neighbour : neighboursToRemoveFromGroups) {
-				removeUserFromGroup(groupName, neighbour);
-				neighbour.getFedIn().setStatus(SubscriptionRequestStatus.EMPTY);
-			}
 		}
 	}
 

--- a/routing-configurer/src/main/java/no/vegvesen/ixn/federation/qpid/QpidClient.java
+++ b/routing-configurer/src/main/java/no/vegvesen/ixn/federation/qpid/QpidClient.java
@@ -166,7 +166,7 @@ public class QpidClient {
 		restTemplate.delete(queuesURL + "?id=" + queueId);
 	}
 
-	public List<String> getInterchangesUserNames(String groupName) {
+	public List<String> getGroupMemberNames(String groupName) {
 		String url = groupsUrl + groupName;
 		ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
 
@@ -185,12 +185,12 @@ public class QpidClient {
 		return groupMemberNames;
 	}
 
-	public void removeInterchangeUserFromGroups(String groupName, String neighbourName) {
+	public void removeMemberFromGroup(String groupName, String neighbourName) {
 		String url = groupsUrl + groupName + "/" + neighbourName;
 		restTemplate.delete(url);
 	}
 
-	public void addInterchangeUserToGroups(String name, String groupName) {
+	public void addMemberToGroup(String name, String groupName) {
 		JSONObject groupJsonObject = new JSONObject();
 		groupJsonObject.put("name", name);
 		String jsonString = groupJsonObject.toString();

--- a/routing-configurer/src/main/java/no/vegvesen/ixn/federation/qpid/QpidClient.java
+++ b/routing-configurer/src/main/java/no/vegvesen/ixn/federation/qpid/QpidClient.java
@@ -185,14 +185,14 @@ public class QpidClient {
 		return groupMemberNames;
 	}
 
-	public void removeMemberFromGroup(String groupName, String neighbourName) {
-		String url = groupsUrl + groupName + "/" + neighbourName;
+	public void removeMemberFromGroup(String memberName, String groupName) {
+		String url = groupsUrl + groupName + "/" + memberName;
 		restTemplate.delete(url);
 	}
 
-	public void addMemberToGroup(String name, String groupName) {
+	public void addMemberToGroup(String memberName, String groupName) {
 		JSONObject groupJsonObject = new JSONObject();
-		groupJsonObject.put("name", name);
+		groupJsonObject.put("name", memberName);
 		String jsonString = groupJsonObject.toString();
 
 		postQpid(groupsUrl, jsonString, groupName);

--- a/routing-configurer/src/main/java/no/vegvesen/ixn/federation/qpid/QpidClient.java
+++ b/routing-configurer/src/main/java/no/vegvesen/ixn/federation/qpid/QpidClient.java
@@ -101,7 +101,7 @@ public class QpidClient {
 		postQpid(queuesURL, jsonString, "/");
 	}
 
-	boolean queueExists(String queueName) {
+	public boolean queueExists(String queueName) {
 		return lookupQueueId(queueName) != null;
 	}
 

--- a/routing-configurer/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/routing-configurer/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -4,16 +4,6 @@
       "name": "routing-configurer.interval",
       "type": "java.lang.String",
       "description": "Time, in milliseconds, between each time neighbours and service providers are added to the message broker."
-    },
-    {
-      "name": "routing-configurer.groups-interval.add",
-      "type": "java.lang.String",
-      "description": "Time, in milliseconds, between each time new neighbours that forwards messages to us will be added to our groups file."
-    },
-    {
-      "name": "routing-configurer.groups-interval.remove",
-      "type": "java.lang.String",
-      "description": "Time, in milliseconds, between each time neighbours no longer forwards messages to us will be removed from our groups file."
     }
   ]
 }

--- a/routing-configurer/src/main/resources/application.properties
+++ b/routing-configurer/src/main/resources/application.properties
@@ -17,8 +17,6 @@ spring.output.ansi.enabled=ALWAYS
 spring.main.web-application-type= NONE
 
 routing-configurer.interval=10000
-routing-configurer.groups-interval.add = 9000
-routing-configurer.groups-interval.remove = 15000
 
 routing-configurer.ssl.trust-store-type=JKS
 routing-configurer.ssl.key-store-type=PKCS12

--- a/routing-configurer/src/test/java/no/vegvesen/ixn/federation/RoutingConfigurerIT.java
+++ b/routing-configurer/src/test/java/no/vegvesen/ixn/federation/RoutingConfigurerIT.java
@@ -1,0 +1,206 @@
+package no.vegvesen.ixn.federation;
+
+import no.vegvesen.ixn.Sink;
+import no.vegvesen.ixn.Source;
+import no.vegvesen.ixn.docker.DockerBaseIT;
+import no.vegvesen.ixn.federation.api.v1_0.SubscriptionStatus;
+import no.vegvesen.ixn.federation.model.*;
+import no.vegvesen.ixn.federation.qpid.QpidClient;
+import no.vegvesen.ixn.federation.qpid.QpidClientConfig;
+import no.vegvesen.ixn.federation.qpid.TestSSLContextConfig;
+import no.vegvesen.ixn.federation.repository.NeighbourRepository;
+import no.vegvesen.ixn.federation.repository.ServiceProviderRepository;
+import no.vegvesen.ixn.ssl.KeystoreDetails;
+import no.vegvesen.ixn.ssl.KeystoreType;
+import no.vegvesen.ixn.ssl.SSLContextFactory;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.client.RestTemplate;
+import org.testcontainers.containers.GenericContainer;
+
+import javax.jms.JMSException;
+import javax.naming.NamingException;
+import javax.net.ssl.SSLContext;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+
+@SuppressWarnings("rawtypes")
+@SpringBootTest(classes = {QpidClient.class, QpidClientConfig.class, TestSSLContextConfig.class})
+@RunWith(SpringRunner.class)
+@ContextConfiguration(initializers = {RoutingConfigurerIT.Initializer.class})
+public class RoutingConfigurerIT extends DockerBaseIT {
+
+	@ClassRule
+	public static GenericContainer qpidContainer = getQpidContainer("qpid", "jks", "localhost.crt", "localhost.crt", "localhost.key");
+
+	private static Logger logger = LoggerFactory.getLogger(RoutingConfigurerIT.class);
+	private final SubscriptionRequest emptySubscriptionRequest = new SubscriptionRequest(SubscriptionRequestStatus.EMPTY, emptySet());
+	private final Capabilities emptyCapabilities = new Capabilities(Capabilities.CapabilitiesStatus.UNKNOWN, emptySet());
+	private static String AMQPS_URL;
+
+	static class Initializer
+			implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+		public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
+			String httpsUrl = "https://localhost:" + qpidContainer.getMappedPort(HTTPS_PORT);
+			String httpUrl = "http://localhost:" + qpidContainer.getMappedPort(8080);
+			logger.info("server url: " + httpsUrl);
+			logger.info("server url: " + httpUrl);
+			AMQPS_URL = "amqps://localhost:" + qpidContainer.getMappedPort(AMQPS_PORT);
+			TestPropertyValues.of(
+					"qpid.rest.api.baseUrl=" + httpsUrl,
+					"qpid.rest.api.vhost=localhost"
+			).applyTo(configurableApplicationContext.getEnvironment());
+		}
+	}
+
+	RoutingConfigurer routingConfigurer;
+
+	@Autowired
+	QpidClient client;
+
+	@Autowired
+	RestTemplate restTemplate;
+
+	@Before
+	public void setUp() {
+		routingConfigurer = new RoutingConfigurer(mock(NeighbourRepository.class), mock(ServiceProviderRepository.class), client);
+	}
+
+	@Test
+	public void interchangeWithOneBindingIsCreated() {
+		Set<Subscription> subscriptions = new HashSet<>(Collections.singletonList(new Subscription("a = b", SubscriptionStatus.REQUESTED)));
+		SubscriptionRequest subscriptionRequest = new SubscriptionRequest(SubscriptionRequestStatus.REQUESTED, subscriptions);
+		Neighbour flounder = new Neighbour("flounder", emptyCapabilities, subscriptionRequest, emptySubscriptionRequest);
+		routingConfigurer.setupSubscriberRouting(flounder);
+		assertThat(client.queueExists(flounder.getName())).isTrue();
+	}
+
+	@Test
+	public void interchangeWithTwoBindingsIsCreated() {
+		Subscription s1 = new Subscription("a = b", SubscriptionStatus.REQUESTED);
+		Subscription s2 = new Subscription("b = c", SubscriptionStatus.REQUESTED);
+		Set<Subscription> subscriptions = new HashSet<>(Arrays.asList(s1, s2));
+		SubscriptionRequest subscriptionRequest = new SubscriptionRequest(SubscriptionRequestStatus.REQUESTED, subscriptions);
+		Neighbour halibut = new Neighbour("halibut", emptyCapabilities, subscriptionRequest, emptySubscriptionRequest);
+		routingConfigurer.setupSubscriberRouting(halibut);
+		assertThat(client.queueExists(halibut.getName())).isTrue();
+	}
+
+	@Test
+	public void interchangeIsBothCreatedAndUpdated() {
+		Set<Subscription> subscriptions = new HashSet<>(Collections.singletonList(new Subscription("a = b", SubscriptionStatus.REQUESTED)));
+		SubscriptionRequest subscriptionRequest = new SubscriptionRequest(SubscriptionRequestStatus.REQUESTED, subscriptions);
+		Neighbour seabass = new Neighbour("seabass", emptyCapabilities, subscriptionRequest, emptySubscriptionRequest);
+		routingConfigurer.setupSubscriberRouting(seabass);
+		assertThat(client.queueExists(seabass.getName())).isTrue();
+		routingConfigurer.setupSubscriberRouting(seabass);
+		assertThat(client.queueExists(seabass.getName())).isTrue();
+	}
+
+	@Test
+	public void interchangeCanUnbindSubscription() {
+		Subscription s1 = new Subscription("a = b", SubscriptionStatus.REQUESTED);
+		Subscription s2 = new Subscription("b = c", SubscriptionStatus.REQUESTED);
+		Set<Subscription> subscriptions = new HashSet<>(Arrays.asList(s1, s2));
+		SubscriptionRequest subscriptionRequest = new SubscriptionRequest(SubscriptionRequestStatus.REQUESTED, subscriptions);
+		Neighbour trout = new Neighbour("trout", emptyCapabilities, subscriptionRequest, emptySubscriptionRequest);
+		routingConfigurer.setupSubscriberRouting(trout);
+		assertThat(client.getQueueBindKeys(trout.getName())).hasSize(2);
+
+		subscriptions = new HashSet<>(Collections.singletonList(s1));
+		subscriptionRequest = new SubscriptionRequest(SubscriptionRequestStatus.REQUESTED, subscriptions);
+		trout = new Neighbour("trout", emptyCapabilities, subscriptionRequest, emptySubscriptionRequest);
+
+		routingConfigurer.setupSubscriberRouting(trout);
+		assertThat(client.getQueueBindKeys(trout.getName())).hasSize(1);
+	}
+
+	@Test
+	public void newServiceProviderCanReadDedicatedOutQueue() throws NamingException, JMSException {
+		ServiceProvider king_gustaf = new ServiceProvider("king_gustaf");
+		routingConfigurer.setupSubscriberRouting(king_gustaf);
+		SSLContext kingGustafSslContext = setUpTestSslContext("jks/king_gustaf.p12");
+		Sink readKingGustafQueue = new Sink(AMQPS_URL, "king_gustaf", kingGustafSslContext);
+		readKingGustafQueue.start();
+		Source writeOnrampQueue = new Source(AMQPS_URL, "onramp", kingGustafSslContext);
+		writeOnrampQueue.start();
+		try {
+			Sink readDlqueue = new Sink(AMQPS_URL, "onramp", kingGustafSslContext);
+			readDlqueue.start();
+			fail("Should not allow king_gustaf to read from queue not granted access on (onramp)");
+		} catch (Exception ignore) {
+		}
+	}
+
+	private static String getFilePathFromClasspathResource(String classpathResource) {
+		URL resource = Thread.currentThread().getContextClassLoader().getResource(classpathResource);
+		if (resource != null) {
+			return resource.getFile();
+		}
+		throw new RuntimeException("Could not load classpath resource " + classpathResource);
+	}
+
+	@Test
+	public void newNeighbourCanNeitherWriteToFedExNorOnramp() throws JMSException, NamingException {
+		HashSet<Subscription> subscriptions = new HashSet<>();
+		subscriptions.add(new Subscription("originatingCountry = 'SE'", SubscriptionStatus.REQUESTED));
+		Neighbour nordea = new Neighbour("nordea", new Capabilities(Capabilities.CapabilitiesStatus.UNKNOWN, emptySet()), new SubscriptionRequest(SubscriptionRequestStatus.REQUESTED, subscriptions), null);
+		routingConfigurer.setupSubscriberRouting(nordea);
+		SSLContext nordeaSslContext = setUpTestSslContext("jks/nordea.p12");
+		try {
+			Source writeFedExExchange = new Source(AMQPS_URL, "fedEx", nordeaSslContext);
+			writeFedExExchange.start();
+			writeFedExExchange.send("Ordinary business at the Nordea office.");
+			fail("Should not allow neighbour nordea to write on (fedEx)");
+		} catch (JMSException ignore) {
+		}
+		try {
+			Source writeOnramp = new Source(AMQPS_URL, "onramp", nordeaSslContext);
+			writeOnramp.start();
+			writeOnramp.send("Make Nordea great again!");
+
+			fail("Should not allow nordea to write on (onramp)");
+		} catch (JMSException ignore) {
+		}
+		theNodeItselfCanReadFromAnyNeighbourQueue("nordea");
+	}
+
+	/**
+	 * Called from newNeighbourCanWriteToFedExButNotOnramp to avoid setting up more neighbour nodes in the test
+	 *
+	 * @param neighbourQueue name of the queue to be read by the node itself
+	 */
+	public void theNodeItselfCanReadFromAnyNeighbourQueue(String neighbourQueue) throws NamingException, JMSException {
+		SSLContext localhostSslContext = setUpTestSslContext("jks/localhost.p12");
+		Sink neighbourSink = new Sink(AMQPS_URL, neighbourQueue, localhostSslContext);
+		neighbourSink.start();
+	}
+
+	public SSLContext setUpTestSslContext(String s) {
+		return SSLContextFactory.sslContextFromKeyAndTrustStores(
+				new KeystoreDetails(getFilePathFromClasspathResource(s), "password", KeystoreType.PKCS12, "password"),
+				new KeystoreDetails(getFilePathFromClasspathResource("jks/truststore.jks"), "password", KeystoreType.JKS));
+	}
+
+}

--- a/routing-configurer/src/test/java/no/vegvesen/ixn/federation/RoutingConfigurerIT.java
+++ b/routing-configurer/src/test/java/no/vegvesen/ixn/federation/RoutingConfigurerIT.java
@@ -186,6 +186,30 @@ public class RoutingConfigurerIT extends DockerBaseIT {
 		theNodeItselfCanReadFromAnyNeighbourQueue("nordea");
 	}
 
+	@Test
+	public void neighbourToreDownWillBeRemovedFromFederatedInterchangesGroup() {
+		Neighbour toreDownNeighbour = new Neighbour("tore-down-neighbour", emptyCapabilities, emptySubscriptionRequest, emptySubscriptionRequest);
+
+		routingConfigurer.setupSubscriberRouting(toreDownNeighbour);
+		assertThat(client.getInterchangesUserNames(QpidClient.FEDERATED_GROUP_NAME)).contains(toreDownNeighbour.getName());
+
+		routingConfigurer.tearDownSubscriberRouting(toreDownNeighbour);
+		assertThat(client.getInterchangesUserNames(QpidClient.FEDERATED_GROUP_NAME)).doesNotContain(toreDownNeighbour.getName());
+	}
+
+	@Test
+	public void subcriberToreDownWillBeRemovedFromSubscribFederatedInterchangesGroup() {
+		ServiceProvider toreDownServiceProvider = new ServiceProvider("tore-down-service-provider");
+
+		routingConfigurer.setupSubscriberRouting(toreDownServiceProvider);
+		assertThat(client.getInterchangesUserNames(QpidClient.SERVICE_PROVIDERS_GROUP_NAME)).contains(toreDownServiceProvider.getName());
+
+		routingConfigurer.tearDownSubscriberRouting(toreDownServiceProvider);
+		assertThat(client.getInterchangesUserNames(QpidClient.SERVICE_PROVIDERS_GROUP_NAME)).doesNotContain(toreDownServiceProvider.getName());
+	}
+
+
+
 	/**
 	 * Called from newNeighbourCanWriteToFedExButNotOnramp to avoid setting up more neighbour nodes in the test
 	 *

--- a/routing-configurer/src/test/java/no/vegvesen/ixn/federation/RoutingConfigurerIT.java
+++ b/routing-configurer/src/test/java/no/vegvesen/ixn/federation/RoutingConfigurerIT.java
@@ -209,12 +209,6 @@ public class RoutingConfigurerIT extends DockerBaseIT {
 	}
 
 
-
-	/**
-	 * Called from newNeighbourCanWriteToFedExButNotOnramp to avoid setting up more neighbour nodes in the test
-	 *
-	 * @param neighbourQueue name of the queue to be read by the node itself
-	 */
 	public void theNodeItselfCanReadFromAnyNeighbourQueue(String neighbourQueue) throws NamingException, JMSException {
 		SSLContext localhostSslContext = setUpTestSslContext("jks/localhost.p12");
 		Sink neighbourSink = new Sink(AMQPS_URL, neighbourQueue, localhostSslContext);

--- a/routing-configurer/src/test/java/no/vegvesen/ixn/federation/RoutingConfigurerIT.java
+++ b/routing-configurer/src/test/java/no/vegvesen/ixn/federation/RoutingConfigurerIT.java
@@ -191,10 +191,10 @@ public class RoutingConfigurerIT extends DockerBaseIT {
 		Neighbour toreDownNeighbour = new Neighbour("tore-down-neighbour", emptyCapabilities, emptySubscriptionRequest, emptySubscriptionRequest);
 
 		routingConfigurer.setupSubscriberRouting(toreDownNeighbour);
-		assertThat(client.getInterchangesUserNames(QpidClient.FEDERATED_GROUP_NAME)).contains(toreDownNeighbour.getName());
+		assertThat(client.getGroupMemberNames(QpidClient.FEDERATED_GROUP_NAME)).contains(toreDownNeighbour.getName());
 
 		routingConfigurer.tearDownSubscriberRouting(toreDownNeighbour);
-		assertThat(client.getInterchangesUserNames(QpidClient.FEDERATED_GROUP_NAME)).doesNotContain(toreDownNeighbour.getName());
+		assertThat(client.getGroupMemberNames(QpidClient.FEDERATED_GROUP_NAME)).doesNotContain(toreDownNeighbour.getName());
 	}
 
 	@Test
@@ -202,10 +202,10 @@ public class RoutingConfigurerIT extends DockerBaseIT {
 		ServiceProvider toreDownServiceProvider = new ServiceProvider("tore-down-service-provider");
 
 		routingConfigurer.setupSubscriberRouting(toreDownServiceProvider);
-		assertThat(client.getInterchangesUserNames(QpidClient.SERVICE_PROVIDERS_GROUP_NAME)).contains(toreDownServiceProvider.getName());
+		assertThat(client.getGroupMemberNames(QpidClient.SERVICE_PROVIDERS_GROUP_NAME)).contains(toreDownServiceProvider.getName());
 
 		routingConfigurer.tearDownSubscriberRouting(toreDownServiceProvider);
-		assertThat(client.getInterchangesUserNames(QpidClient.SERVICE_PROVIDERS_GROUP_NAME)).doesNotContain(toreDownServiceProvider.getName());
+		assertThat(client.getGroupMemberNames(QpidClient.SERVICE_PROVIDERS_GROUP_NAME)).doesNotContain(toreDownServiceProvider.getName());
 	}
 
 

--- a/routing-configurer/src/test/java/no/vegvesen/ixn/federation/qpid/QpidClientIT.java
+++ b/routing-configurer/src/test/java/no/vegvesen/ixn/federation/qpid/QpidClientIT.java
@@ -99,9 +99,9 @@ public class QpidClientIT extends DockerBaseIT {
 	@Test
 	public void addAnInterchangeToGroups() {
 		String newUser = "herring";
-		client.addInterchangeUserToGroups(newUser, FEDERATED_GROUP_NAME);
+		client.addMemberToGroup(newUser, FEDERATED_GROUP_NAME);
 
-		List<String> userNames = client.getInterchangesUserNames(FEDERATED_GROUP_NAME);
+		List<String> userNames = client.getGroupMemberNames(FEDERATED_GROUP_NAME);
 
 		assertThat(userNames).contains(newUser);
 	}
@@ -109,12 +109,12 @@ public class QpidClientIT extends DockerBaseIT {
 	@Test
 	public void deleteAnInterchangeFromGroups() {
 		String deleteUser = "carp";
-		client.addInterchangeUserToGroups(deleteUser, FEDERATED_GROUP_NAME);
-		List<String> userNames = client.getInterchangesUserNames(FEDERATED_GROUP_NAME);
+		client.addMemberToGroup(deleteUser, FEDERATED_GROUP_NAME);
+		List<String> userNames = client.getGroupMemberNames(FEDERATED_GROUP_NAME);
 		assertThat(userNames).contains(deleteUser);
 
-		client.removeInterchangeUserFromGroups(FEDERATED_GROUP_NAME, deleteUser);
-		userNames = client.getInterchangesUserNames(FEDERATED_GROUP_NAME);
+		client.removeMemberFromGroup(FEDERATED_GROUP_NAME, deleteUser);
+		userNames = client.getGroupMemberNames(FEDERATED_GROUP_NAME);
 		assertThat(userNames).doesNotContain(deleteUser);
 	}
 

--- a/routing-configurer/src/test/java/no/vegvesen/ixn/federation/qpid/QpidClientIT.java
+++ b/routing-configurer/src/test/java/no/vegvesen/ixn/federation/qpid/QpidClientIT.java
@@ -35,6 +35,7 @@ import static no.vegvesen.ixn.federation.qpid.QpidClient.SERVICE_PROVIDERS_GROUP
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
+
 @SuppressWarnings("rawtypes")
 @SpringBootTest(classes = {QpidClient.class, QpidClientConfig.class, TestSSLContextConfig.class})
 @RunWith(SpringRunner.class)
@@ -221,7 +222,7 @@ public class QpidClientIT extends DockerBaseIT {
 	@Test
 	public void addAccessBuildsUpRules() {
 		List<String> initialACL = client.getACL();
-		client.addReadAccess(new ServiceProvider("routing_configurer"), "onramp");
+		client.addReadAccess("routing_configurer", "onramp");
 		List<String> newACL = client.getACL();
 		assertThat(newACL).hasSize(initialACL.size() + 1);
 	}
@@ -236,7 +237,7 @@ public class QpidClientIT extends DockerBaseIT {
 		acl.add("ACL ALLOW-LOG " + SERVICE_PROVIDERS_GROUP_NAME + " ACCESS VIRTUALHOST name = \"localhost\"");
 		acl.add("ACL ALLOW-LOG interchange CONSUME QUEUE name = \"onramp\"");
 		acl.add("ACL DENY-LOG ALL ALL ALL");
-		LinkedList<String> newAcl = new LinkedList<>(client.addOneConsumeRuleBeforeLastRule(new ServiceProvider("king_harald"), "king_harald", acl));
+		LinkedList<String> newAcl = new LinkedList<>(client.addOneConsumeRuleBeforeLastRule("king_harald", "king_harald", acl));
 		assertThat(acl.getFirst()).isEqualTo(newAcl.getFirst());
 		assertThat(acl.getLast()).isEqualTo(newAcl.getLast());
 		assertThat(newAcl.get(newAcl.size()-2)).contains("king_harald");

--- a/routing-configurer/src/test/java/no/vegvesen/ixn/federation/qpid/QpidClientIT.java
+++ b/routing-configurer/src/test/java/no/vegvesen/ixn/federation/qpid/QpidClientIT.java
@@ -16,7 +16,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.RestTemplate;
 import org.testcontainers.containers.GenericContainer;
 
-import java.net.URL;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -116,14 +115,6 @@ public class QpidClientIT extends DockerBaseIT {
 		client.removeMemberFromGroup(deleteUser, FEDERATED_GROUP_NAME);
 		userNames = client.getGroupMemberNames(FEDERATED_GROUP_NAME);
 		assertThat(userNames).doesNotContain(deleteUser);
-	}
-
-	private static String getFilePathFromClasspathResource(String classpathResource) {
-		URL resource = Thread.currentThread().getContextClassLoader().getResource(classpathResource);
-		if (resource != null) {
-			return resource.getFile();
-		}
-		throw new RuntimeException("Could not load classpath resource " + classpathResource);
 	}
 
 	@Test

--- a/routing-configurer/src/test/java/no/vegvesen/ixn/federation/qpid/QpidClientIT.java
+++ b/routing-configurer/src/test/java/no/vegvesen/ixn/federation/qpid/QpidClientIT.java
@@ -1,13 +1,6 @@
 package no.vegvesen.ixn.federation.qpid;
 
-import no.vegvesen.ixn.Sink;
-import no.vegvesen.ixn.Source;
-import no.vegvesen.ixn.federation.api.v1_0.SubscriptionStatus;
 import no.vegvesen.ixn.docker.DockerBaseIT;
-import no.vegvesen.ixn.federation.model.*;
-import no.vegvesen.ixn.ssl.KeystoreDetails;
-import no.vegvesen.ixn.ssl.KeystoreType;
-import no.vegvesen.ixn.ssl.SSLContextFactory;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,18 +16,13 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.RestTemplate;
 import org.testcontainers.containers.GenericContainer;
 
-import javax.jms.JMSException;
-import javax.naming.NamingException;
-import javax.net.ssl.SSLContext;
 import java.net.URL;
-import java.util.*;
+import java.util.LinkedList;
+import java.util.List;
 
-import static java.util.Collections.emptySet;
 import static no.vegvesen.ixn.federation.qpid.QpidClient.FEDERATED_GROUP_NAME;
 import static no.vegvesen.ixn.federation.qpid.QpidClient.SERVICE_PROVIDERS_GROUP_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
-
 
 @SuppressWarnings("rawtypes")
 @SpringBootTest(classes = {QpidClient.class, QpidClientConfig.class, TestSSLContextConfig.class})
@@ -42,16 +30,10 @@ import static org.junit.Assert.fail;
 @ContextConfiguration(initializers = {QpidClientIT.Initializer.class})
 public class QpidClientIT extends DockerBaseIT {
 
-
 	@ClassRule
 	public static GenericContainer qpidContainer = getQpidContainer("qpid", "jks", "localhost.crt", "localhost.crt", "localhost.key");
 
 	private static Logger logger = LoggerFactory.getLogger(QpidClientIT.class);
-	private static final String NW_EX = "nwEx";
-	private static final String FED_EX = "fedEx";
-	private final SubscriptionRequest emptySubscriptionRequest = new SubscriptionRequest(SubscriptionRequestStatus.EMPTY, emptySet());
-	private final Capabilities emptyCapabilities = new Capabilities(Capabilities.CapabilitiesStatus.UNKNOWN, emptySet());
-	private static String AMQPS_URL;
 	private static Integer MAPPED_HTTPS_PORT;
 
 	static class Initializer
@@ -62,7 +44,6 @@ public class QpidClientIT extends DockerBaseIT {
 			String httpUrl = "http://localhost:" + qpidContainer.getMappedPort(8080);
 			logger.info("server url: " + httpsUrl);
 			logger.info("server url: " + httpUrl);
-			AMQPS_URL = "amqps://localhost:" + qpidContainer.getMappedPort(AMQPS_PORT);
 			TestPropertyValues.of(
 					"qpid.rest.api.baseUrl=" + httpsUrl,
 					"qpid.rest.api.vhost=localhost"
@@ -105,69 +86,6 @@ public class QpidClientIT extends DockerBaseIT {
 	}
 
 	@Test
-	public void interchangeWithOneBindingIsCreated() {
-		Set<Subscription> subscriptions = new HashSet<>(Collections.singletonList(new Subscription("a = b", SubscriptionStatus.REQUESTED)));
-		SubscriptionRequest subscriptionRequest = new SubscriptionRequest(SubscriptionRequestStatus.REQUESTED, subscriptions);
-		Neighbour flounder = new Neighbour("flounder", emptyCapabilities, subscriptionRequest, emptySubscriptionRequest);
-		setupRouting(flounder, NW_EX);
-		assertThat(client.queueExists(flounder.getName())).isTrue();
-	}
-
-	//todo: users of this is candidate for RoutingConfigurerIT
-	private void setupRouting(Subscriber subscriber, String exchangeName) {
-		client.createQueue(subscriber.getName());
-		client.addReadAccess(subscriber.getName(), subscriber.getName());
-		for (Subscription subscription : subscriber.getSubscriptionRequest().getSubscriptions()) {
-			client.addBinding(subscription.getSelector(), subscriber.getName(), subscription.bindKey(), exchangeName);
-		}
-		Set<String> existing = client.getQueueBindKeys(subscriber.getName());
-		Set<String> unwantedBindKeys = subscriber.getUnwantedBindKeys(existing);
-		for (String unwantedBindKey : unwantedBindKeys) {
-			client.unbindBindKey(subscriber.getName(), unwantedBindKey, exchangeName);
-		}
-	}
-
-	@Test
-	public void interchangeWithTwoBindingsIsCreated() {
-		Subscription s1 = new Subscription("a = b", SubscriptionStatus.REQUESTED);
-		Subscription s2 = new Subscription("b = c", SubscriptionStatus.REQUESTED);
-		Set<Subscription> subscriptions = new HashSet<>(Arrays.asList(s1, s2));
-		SubscriptionRequest subscriptionRequest = new SubscriptionRequest(SubscriptionRequestStatus.REQUESTED, subscriptions);
-		Neighbour halibut = new Neighbour("halibut", emptyCapabilities, subscriptionRequest, emptySubscriptionRequest);
-		setupRouting(halibut, NW_EX);
-		assertThat(client.queueExists(halibut.getName())).isTrue();
-	}
-
-	@Test
-	public void interchangeIsBothCreatedAndUpdated() {
-		Set<Subscription> subscriptions = new HashSet<>(Collections.singletonList(new Subscription("a = b", SubscriptionStatus.REQUESTED)));
-		SubscriptionRequest subscriptionRequest = new SubscriptionRequest(SubscriptionRequestStatus.REQUESTED, subscriptions);
-		Neighbour seabass = new Neighbour("seabass", emptyCapabilities, subscriptionRequest, emptySubscriptionRequest);
-		setupRouting(seabass, NW_EX);
-		assertThat(client.queueExists(seabass.getName())).isTrue();
-		setupRouting(seabass, NW_EX);
-		assertThat(client.queueExists(seabass.getName())).isTrue();
-	}
-
-	@Test
-	public void interchangeCanUnbindSubscription() {
-		Subscription s1 = new Subscription("a = b", SubscriptionStatus.REQUESTED);
-		Subscription s2 = new Subscription("b = c", SubscriptionStatus.REQUESTED);
-		Set<Subscription> subscriptions = new HashSet<>(Arrays.asList(s1, s2));
-		SubscriptionRequest subscriptionRequest = new SubscriptionRequest(SubscriptionRequestStatus.REQUESTED, subscriptions);
-		Neighbour trout = new Neighbour("trout", emptyCapabilities, subscriptionRequest, emptySubscriptionRequest);
-		setupRouting(trout, NW_EX);
-		assertThat(client.getQueueBindKeys(trout.getName())).hasSize(2);
-
-		subscriptions = new HashSet<>(Collections.singletonList(s1));
-		subscriptionRequest = new SubscriptionRequest(SubscriptionRequestStatus.REQUESTED, subscriptions);
-		trout = new Neighbour("trout", emptyCapabilities, subscriptionRequest, emptySubscriptionRequest);
-
-		setupRouting(trout, NW_EX);
-		assertThat(client.getQueueBindKeys(trout.getName())).hasSize(1);
-	}
-
-	@Test
 	public void tearDownQueue() {
 		//Set up a new queue
 		client.createQueue("crab");
@@ -200,23 +118,6 @@ public class QpidClientIT extends DockerBaseIT {
 		assertThat(userNames).doesNotContain(deleteUser);
 	}
 
-	@Test
-	public void newServiceProviderCanReadDedicatedOutQueue() throws NamingException, JMSException {
-		ServiceProvider king_gustaf = new ServiceProvider("king_gustaf");
-		setupRouting(king_gustaf, NW_EX);
-		client.addInterchangeUserToGroups(king_gustaf.getName(), SERVICE_PROVIDERS_GROUP_NAME);
-		SSLContext kingGustafSslContext = setUpTestSslContext("jks/king_gustaf.p12");
-		Sink readKingGustafQueue = new Sink(AMQPS_URL, "king_gustaf", kingGustafSslContext);
-		readKingGustafQueue.start();
-		Source writeOnrampQueue = new Source(AMQPS_URL, "onramp", kingGustafSslContext);
-		writeOnrampQueue.start();
-		try {
-			Sink readDlqueue = new Sink(AMQPS_URL, "onramp", kingGustafSslContext);
-			readDlqueue.start();
-			fail("Should not allow king_gustaf to read from queue not granted access on (onramp)");
-		} catch (Exception ignore) { }
-	}
-
 	private static String getFilePathFromClasspathResource(String classpathResource) {
 		URL resource = Thread.currentThread().getContextClassLoader().getResource(classpathResource);
 		if (resource != null) {
@@ -233,7 +134,6 @@ public class QpidClientIT extends DockerBaseIT {
 		assertThat(newACL).hasSize(initialACL.size() + 1);
 	}
 
-
 	@Test
 	public void addOneConsumeRuleBeforeLastRule() {
 		LinkedList<String> acl = new LinkedList<>();
@@ -247,48 +147,6 @@ public class QpidClientIT extends DockerBaseIT {
 		assertThat(acl.getFirst()).isEqualTo(newAcl.getFirst());
 		assertThat(acl.getLast()).isEqualTo(newAcl.getLast());
 		assertThat(newAcl.get(newAcl.size()-2)).contains("king_harald");
-	}
-
-	@Test
-	public void newNeighbourCanNeitherWriteToFedExNorOnramp() throws JMSException, NamingException {
-		HashSet<Subscription> subscriptions = new HashSet<>();
-		subscriptions.add(new Subscription("originatingCountry = 'SE'", SubscriptionStatus.REQUESTED));
-		Neighbour nordea = new Neighbour("nordea", new Capabilities(Capabilities.CapabilitiesStatus.UNKNOWN, emptySet()), new SubscriptionRequest(SubscriptionRequestStatus.REQUESTED, subscriptions), null);
-		setupRouting(nordea, NW_EX);
-		client.addInterchangeUserToGroups(nordea.getName(), FEDERATED_GROUP_NAME);
-		SSLContext nordeaSslContext = setUpTestSslContext("jks/nordea.p12");
-		try {
-			Source writeFedExExchange = new Source(AMQPS_URL, "fedEx", nordeaSslContext);
-			writeFedExExchange.start();
-			writeFedExExchange.send("Ordinary business at the Nordea office.");
-			fail("Should not allow neighbour nordea to write on (fedEx)");
-		} catch (JMSException ignore) {
-		}
-		try {
-			Source writeOnramp = new Source(AMQPS_URL, "onramp", nordeaSslContext);
-			writeOnramp.start();
-			writeOnramp.send("Make Nordea great again!");
-
-			fail("Should not allow nordea to write on (onramp)");
-		} catch (JMSException ignore) { }
-		theNodeItselfCanReadFromAnyNeighbourQueue("nordea");
-	}
-
-
-	/**
-	 * Called from newNeighbourCanWriteToFedExButNotOnramp to avoid setting up more neighbour nodes in the test
-	 * @param neighbourQueue name of the queue to be read by the node itself
-	 */
-	public void theNodeItselfCanReadFromAnyNeighbourQueue(String neighbourQueue) throws NamingException, JMSException {
-		SSLContext localhostSslContext = setUpTestSslContext("jks/localhost.p12");
-		Sink neighbourSink = new Sink(AMQPS_URL, neighbourQueue, localhostSslContext);
-		neighbourSink.start();
-	}
-
-	public SSLContext setUpTestSslContext(String s) {
-		return SSLContextFactory.sslContextFromKeyAndTrustStores(
-				new KeystoreDetails(getFilePathFromClasspathResource(s), "password", KeystoreType.PKCS12, "password"),
-				new KeystoreDetails(getFilePathFromClasspathResource("jks/truststore.jks"), "password", KeystoreType.JKS));
 	}
 
 	@Test

--- a/routing-configurer/src/test/java/no/vegvesen/ixn/federation/qpid/QpidClientIT.java
+++ b/routing-configurer/src/test/java/no/vegvesen/ixn/federation/qpid/QpidClientIT.java
@@ -113,7 +113,7 @@ public class QpidClientIT extends DockerBaseIT {
 		List<String> userNames = client.getGroupMemberNames(FEDERATED_GROUP_NAME);
 		assertThat(userNames).contains(deleteUser);
 
-		client.removeMemberFromGroup(FEDERATED_GROUP_NAME, deleteUser);
+		client.removeMemberFromGroup(deleteUser, FEDERATED_GROUP_NAME);
 		userNames = client.getGroupMemberNames(FEDERATED_GROUP_NAME);
 		assertThat(userNames).doesNotContain(deleteUser);
 	}

--- a/routing-configurer/src/test/java/no/vegvesen/ixn/federation/qpid/QpidClientIT.java
+++ b/routing-configurer/src/test/java/no/vegvesen/ixn/federation/qpid/QpidClientIT.java
@@ -35,6 +35,7 @@ import static no.vegvesen.ixn.federation.qpid.QpidClient.SERVICE_PROVIDERS_GROUP
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
+@SuppressWarnings("rawtypes")
 @SpringBootTest(classes = {QpidClient.class, QpidClientConfig.class, TestSSLContextConfig.class})
 @RunWith(SpringRunner.class)
 @ContextConfiguration(initializers = {QpidClientIT.Initializer.class})
@@ -242,16 +243,13 @@ public class QpidClientIT extends DockerBaseIT {
 	}
 
 	@Test
-	public void newNeighbourCanWriteToFedExButNotOnramp() throws JMSException, NamingException {
+	public void newNeighbourCanNotWriteToOnramp() throws JMSException, NamingException {
 		HashSet<Subscription> subscriptions = new HashSet<>();
 		subscriptions.add(new Subscription("originatingCountry = 'SE'", SubscriptionStatus.REQUESTED));
 		Neighbour nordea = new Neighbour("nordea", new Capabilities(Capabilities.CapabilitiesStatus.UNKNOWN, emptySet()), new SubscriptionRequest(SubscriptionRequestStatus.REQUESTED, subscriptions), null);
 		client.setupRouting(nordea, NW_EX);
 		client.addInterchangeUserToGroups(nordea.getName(), FEDERATED_GROUP_NAME);
 		SSLContext nordeaSslContext = setUpTestSslContext("jks/nordea.p12");
-		Source writeFedExExchange = new Source(AMQPS_URL, "fedEx", nordeaSslContext);
-		writeFedExExchange.start();
-		writeFedExExchange.send("Ordinary business at the Nordea office.");
 		try {
 			Source writeOnramp = new Source(AMQPS_URL, "onramp", nordeaSslContext);
 			writeOnramp.start();

--- a/routing-configurer/src/test/java/no/vegvesen/ixn/federation/qpid/QuadTreeFilteringIT.java
+++ b/routing-configurer/src/test/java/no/vegvesen/ixn/federation/qpid/QuadTreeFilteringIT.java
@@ -65,9 +65,9 @@ public class QuadTreeFilteringIT extends DockerBaseIT {
 	@Before
 	public void setUp() {
 		//It is not normal for a service provider to be administrator - just to avoid setting up InterchangeApp by letting service provider send to nwEx
-		List<String> administrators = qpidClient.getInterchangesUserNames("administrators");
+		List<String> administrators = qpidClient.getGroupMemberNames("administrators");
 		if (!administrators.contains("king_gustaf")) {
-			qpidClient.addInterchangeUserToGroups("king_gustaf", "administrators");
+			qpidClient.addMemberToGroup("king_gustaf", "administrators");
 		}
 	}
 

--- a/routing-configurer/src/test/java/no/vegvesen/ixn/federation/qpid/QuadTreeFilteringIT.java
+++ b/routing-configurer/src/test/java/no/vegvesen/ixn/federation/qpid/QuadTreeFilteringIT.java
@@ -102,7 +102,9 @@ public class QuadTreeFilteringIT extends DockerBaseIT {
 	private Message sendReceiveMessageNeighbour(String messageQuadTreeTiles, String selector) throws Exception {
 		Subscription subscription = new Subscription(selector, SubscriptionStatus.REQUESTED);
 		Neighbour king_gustaf = new Neighbour("king_gustaf", null, new SubscriptionRequest(SubscriptionRequestStatus.REQUESTED, Sets.newLinkedHashSet(subscription)), null);
-		qpidClient.setupRouting(king_gustaf, "nwEx");
+		qpidClient.createQueue(king_gustaf.getName());
+		qpidClient.addReadAccess(king_gustaf.getName(), king_gustaf.getName());
+		qpidClient.addBinding(subscription.getSelector(), king_gustaf.getName(), subscription.bindKey(), "nwEx");
 
 		SSLContext sslContext = TestKeystoreHelper.sslContext("jks/king_gustaf.p12", "jks/truststore.jks");
 
@@ -132,7 +134,9 @@ public class QuadTreeFilteringIT extends DockerBaseIT {
 	private Message sendReceiveMessageServiceProvider(String messageQuadTreeTiles, DataType subscription) throws Exception {
 		ServiceProvider king_gustaf = new ServiceProvider("king_gustaf");
 		king_gustaf.setLocalSubscriptionRequest(new LocalSubscriptionRequest(SubscriptionRequestStatus.REQUESTED, subscription));
-		qpidClient.setupRouting(king_gustaf, "nwEx");
+		qpidClient.createQueue(king_gustaf.getName());
+		qpidClient.addReadAccess(king_gustaf.getName(), king_gustaf.getName());
+		qpidClient.addBinding(subscription.toSelector(), king_gustaf.getName(), ""+subscription.toSelector().hashCode(), "nwEx");
 
 		SSLContext sslContext = TestKeystoreHelper.sslContext("jks/king_gustaf.p12", "jks/truststore.jks");
 

--- a/routing-configurer/src/test/resources/qpid/vhost.json
+++ b/routing-configurer/src/test/resources/qpid/vhost.json
@@ -74,15 +74,6 @@
           }
         },
         {
-          "objectType": "EXCHANGE",
-          "identity": "federated-interchanges",
-          "operation": "PUBLISH",
-          "outcome": "ALLOW_LOG",
-          "attributes": {
-            "NAME": "fedEx"
-          }
-        },
-        {
           "objectType": "VIRTUALHOST",
           "identity": "federated-interchanges",
           "operation": "ACCESS",


### PR DESCRIPTION
Neighbours that subscribe to messages from us are added to group 'federated-interchanges' in QPID to allow these neighbours to log in to the message broker so they can collect their messages.

No longer can a neighbour publish messages to the exchange 'fedEx', federated messages are published on 'fedEx' by our own server user - as fixed earlier.