### PR TITLE
We use explicit eager fetch, should not need spring.jpa.open-in-view …

### DIFF
--- a/message-collector/src/main/resources/application.properties
+++ b/message-collector/src/main/resources/application.properties
@@ -7,6 +7,7 @@ spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults = false
 # Use update for a stable database(none for prod).
 # Create-drop will wipe the database when the spring app stops.
 spring.jpa.hibernate.ddl-auto = update
+spring.jpa.open-in-view=false
 
 # logging
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} [%-13.13thread] %-5level %logger{36}  - %msg%n

--- a/neighbour-discoverer-app/src/main/resources/application.properties
+++ b/neighbour-discoverer-app/src/main/resources/application.properties
@@ -13,6 +13,7 @@ spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults = false
 # use create-drop for testing; wipes the database when the application is stopped.
 # update for more stable, none for production.
 spring.jpa.hibernate.ddl-auto = update
+spring.jpa.open-in-view=false
 
 # ------------------------
 # Logging

--- a/neighbour-model/src/test/resources/application.properties
+++ b/neighbour-model/src/test/resources/application.properties
@@ -4,6 +4,7 @@ spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults = false
 # Use update for a stable database(none for prod).
 # Create-drop will wipe the database when the spring app stops.
 spring.jpa.hibernate.ddl-auto = create-drop
+spring.jpa.open-in-view=false
 
 # logging
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg %ex{full}%n

--- a/neighbour-server/src/main/resources/application.properties
+++ b/neighbour-server/src/main/resources/application.properties
@@ -11,6 +11,7 @@ spring.datasource.password= federation
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQL9Dialect
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults = false
 spring.jpa.hibernate.ddl-auto = update
+spring.jpa.open-in-view=false
 
 # ------------------------
 # Logging

--- a/neighbour-service/src/test/resources/application.properties
+++ b/neighbour-service/src/test/resources/application.properties
@@ -3,6 +3,7 @@ spring.datasource.url=jdbc:postgresql://localhost:7070/federation
 spring.datasource.username=federation
 spring.datasource.password=federation
 spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.open-in-view=false
 
 logging.pattern.console=%d{yyyy-MM-dd} %d{HH:mm:ss}  [%-12.12thread]  %highlight(%-5level)  %-30.30logger{30}  %-42method  [%X{local_interchange}  %X{remote_interchange}]  - %msg %ex{full}%n
 logging.level.root=debug

--- a/onboard-server/src/main/resources/application.properties
+++ b/onboard-server/src/main/resources/application.properties
@@ -7,6 +7,7 @@ spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults = false
 # Use update for a stable database(none for prod).
 # Create-drop will wipe the database when the spring app stops.
 spring.jpa.hibernate.ddl-auto = update
+spring.jpa.open-in-view=false
 
 # logging
 logging.pattern.console=%d{yyyy-MM-dd} %d{HH:mm:ss}  [%-12.12thread]  %highlight(%-5level)  %-30.30logger{30}  %-42method  [%X{local_interchange}  %X{service_provider}]  - %msg %ex{full}%n

--- a/onboard-server/src/test/resources/application.properties
+++ b/onboard-server/src/test/resources/application.properties
@@ -7,6 +7,7 @@ spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults = false
 # Use update for a stable database(none for prod).
 # Create-drop will wipe the database when the spring app stops.
 spring.jpa.hibernate.ddl-auto = update
+spring.jpa.open-in-view=false
 
 # logging
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg %ex{full}%n

--- a/onboard-service/src/test/resources/application.properties
+++ b/onboard-service/src/test/resources/application.properties
@@ -5,6 +5,7 @@ spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults = false
 # Use update for a stable database(none for prod).
 # Create-drop will wipe the database when the spring app stops.
 spring.jpa.hibernate.ddl-auto = update
+spring.jpa.open-in-view=false
 
 # logging
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg %ex{full}%n

--- a/routing-configurer-app/src/main/resources/application.properties
+++ b/routing-configurer-app/src/main/resources/application.properties
@@ -6,6 +6,7 @@ spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults = false
 # use create-drop for testing; wipes the database when the application is stopped.
 # update for more stable, none for production.
 spring.jpa.hibernate.ddl-auto = update
+spring.jpa.open-in-view=false
 
 # logging
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg %ex{full}%n


### PR DESCRIPTION
We use explicit eager fetch, does not need spring.jpa.open-in-view set to true.


Based on experience on startup of **neighbour-server**:

2020-08-13 10:43:41  [main        ]  WARN   figuration$JpaWebConfiguration  openEntityManagerInViewInterceptor          [  ]  - spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning