### PR TITLE
Create-drop DB handling for tests is moved

### DIFF
--- a/neighbour-model/src/test/resources/application.properties
+++ b/neighbour-model/src/test/resources/application.properties
@@ -3,7 +3,6 @@ spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQL9Diale
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults = false
 # Use update for a stable database(none for prod).
 # Create-drop will wipe the database when the spring app stops.
-spring.jpa.hibernate.ddl-auto = create-drop
 spring.jpa.open-in-view=false
 
 # logging

--- a/neighbour-service/src/test/resources/application.properties
+++ b/neighbour-service/src/test/resources/application.properties
@@ -2,7 +2,6 @@ spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialec
 spring.datasource.url=jdbc:postgresql://localhost:7070/federation
 spring.datasource.username=federation
 spring.datasource.password=federation
-spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.open-in-view=false
 
 logging.pattern.console=%d{yyyy-MM-dd} %d{HH:mm:ss}  [%-12.12thread]  %highlight(%-5level)  %-30.30logger{30}  %-42method  [%X{local_interchange}  %X{remote_interchange}]  - %msg %ex{full}%n

--- a/onboard-server/src/test/resources/application.properties
+++ b/onboard-server/src/test/resources/application.properties
@@ -6,7 +6,6 @@ spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQL9Diale
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults = false
 # Use update for a stable database(none for prod).
 # Create-drop will wipe the database when the spring app stops.
-spring.jpa.hibernate.ddl-auto = update
 spring.jpa.open-in-view=false
 
 # logging

--- a/testcontainers-init-postgres/src/main/java/no/vegvesen/ixn/postgresinit/PostgresTestcontainerInitializer.java
+++ b/testcontainers-init-postgres/src/main/java/no/vegvesen/ixn/postgresinit/PostgresTestcontainerInitializer.java
@@ -22,7 +22,8 @@ public class PostgresTestcontainerInitializer {
 					String.format("spring.datasource.url: jdbc:postgresql://localhost:%s/%s", postgresContainer.getMappedPort(5432), FEDERATION),
 					"spring.datasource.username: " + FEDERATION,
 					"spring.datasource.password: " + FEDERATION,
-					"spring.datasource.driver-class-name: org.postgresql.Driver"
+					"spring.datasource.driver-class-name: org.postgresql.Driver",
+					"spring.jpa.hibernate.ddl-auto : create-drop"
 			).applyTo(configurableApplicationContext.getEnvironment());
 		}
 	}


### PR DESCRIPTION
From application.properties to initializer class to avoid mishaps