### PR TITLE
Pqid restart

### DIFF
--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Templating Interchange helm chart
         working-directory: ./helm/interchange
         run: |
-          helm template -f example_values.yml .   
+          helm template -f example_values.yml .
 
   build:
     runs-on: ubuntu-latest

--- a/routing-configurer/src/main/java/no/vegvesen/ixn/federation/RoutingConfigurer.java
+++ b/routing-configurer/src/main/java/no/vegvesen/ixn/federation/RoutingConfigurer.java
@@ -119,7 +119,9 @@ public class RoutingConfigurer {
 				addSubscriberToGroup(FEDERATED_GROUP_NAME, neighbourName);
 				for (Capability cap : matchingCaps) {
 					if (cap.exchangeExists()) {
-						bindSubscriptionQueue(cap.getCapabilityExchangeName(), subscription);
+						if (qpidClient.exchangeExists(cap.getCapabilityExchangeName())) {
+							bindSubscriptionQueue(cap.getCapabilityExchangeName(), subscription);
+						}
 					}
 				}
 				NeighbourEndpoint endpoint = createEndpoint(neighbourService.getNodeName(), neighbourService.getMessagePort(), queueName);

--- a/routing-configurer/src/main/java/no/vegvesen/ixn/federation/ServiceProviderRouter.java
+++ b/routing-configurer/src/main/java/no/vegvesen/ixn/federation/ServiceProviderRouter.java
@@ -12,6 +12,7 @@ import no.vegvesen.ixn.federation.service.OutgoingMatchDiscoveryService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
@@ -22,6 +23,7 @@ import static no.vegvesen.ixn.federation.qpid.QpidClient.SERVICE_PROVIDERS_GROUP
 import static no.vegvesen.ixn.federation.qpid.QpidClient.CLIENTS_PRIVATE_CHANNELS_GROUP_NAME;
 
 @Component
+@ConfigurationPropertiesScan("no.vegvesen.ixn")
 public class ServiceProviderRouter {
 
     private static Logger logger = LoggerFactory.getLogger(ServiceProviderRouter.class);
@@ -383,14 +385,12 @@ public class ServiceProviderRouter {
                 if (delivery.getStatus().equals(LocalDeliveryStatus.CREATED)) {
                     if (!qpidClient.exchangeExists(delivery.getExchangeName())) {
                         String joinedSelector = joinDeliverySelectorWithCapabilitySelector(match.getCapability(), delivery.getSelector());
-                        //match.setSelector(joinedSelector);
                         qpidClient.createDirectExchange(delivery.getExchangeName());
                         qpidClient.addWriteAccess(serviceProvider.getName(), delivery.getExchangeName());
                         qpidClient.bindDirectExchange(joinedSelector, delivery.getExchangeName(), match.getCapability().getCapabilityExchangeName());
                         outgoingMatchDiscoveryService.updateOutgoingMatchToUp(match);
                     } else {
                         String joinedSelector = joinDeliverySelectorWithCapabilitySelector(match.getCapability(), delivery.getSelector());
-                        //match.setSelector(joinedSelector);
                         qpidClient.bindDirectExchange(joinedSelector, delivery.getExchangeName(), match.getCapability().getCapabilityExchangeName());
                         outgoingMatchDiscoveryService.updateOutgoingMatchToUp(match);
                     }
@@ -416,6 +416,7 @@ public class ServiceProviderRouter {
             outgoingMatchDiscoveryService.updateOutgoingMatchToDeleted(match);
         }
 
+        //Have to do something here, think that the delivery exchange name will change in restart
         Set<LocalDelivery> deliveries = serviceProvider.getDeliveries();
         for (LocalDelivery delivery : deliveries) {
             if (!delivery.getStatus().equals(LocalDeliveryStatus.ILLEGAL)) {

--- a/routing-configurer/src/test/java/no/vegvesen/ixn/federation/MessageValidatingSelectorCreatorTest.java
+++ b/routing-configurer/src/test/java/no/vegvesen/ixn/federation/MessageValidatingSelectorCreatorTest.java
@@ -64,7 +64,7 @@ public class MessageValidatingSelectorCreatorTest {
         assertThat(selector).contains("originatingCountry = 'NO'");
         assertThat(selector).contains("protocolVersion = '1.0'");
         assertThat(selector).contains("quadTree like");
-        assertThat(selector).contains("publicationType like");
+        assertThat(selector).contains("publicationType =");
         System.out.println(selector);
     }
 }

--- a/routing-configurer/src/test/java/no/vegvesen/ixn/federation/QpidRestartIT.java
+++ b/routing-configurer/src/test/java/no/vegvesen/ixn/federation/QpidRestartIT.java
@@ -1,0 +1,191 @@
+package no.vegvesen.ixn.federation;
+
+import no.vegvesen.ixn.docker.KeysContainer;
+import no.vegvesen.ixn.docker.QpidContainer;
+import no.vegvesen.ixn.docker.QpidDockerBaseIT;
+import no.vegvesen.ixn.federation.model.*;
+import no.vegvesen.ixn.federation.properties.InterchangeNodeProperties;
+import no.vegvesen.ixn.federation.qpid.QpidClient;
+import no.vegvesen.ixn.federation.qpid.QpidClientConfig;
+import no.vegvesen.ixn.federation.qpid.RoutingConfigurerProperties;
+import no.vegvesen.ixn.federation.repository.ServiceProviderRepository;
+import no.vegvesen.ixn.federation.service.MatchDiscoveryService;
+import no.vegvesen.ixn.federation.service.NeighbourService;
+import no.vegvesen.ixn.federation.service.OutgoingMatchDiscoveryService;
+import no.vegvesen.ixn.federation.ssl.TestSSLProperties;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.net.ssl.SSLContext;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.*;
+
+
+
+@SpringBootTest(classes = {QpidClient.class, RoutingConfigurerProperties.class, QpidClientConfig.class, TestSSLContextConfigGeneratedExternalKeys.class, TestSSLProperties.class, ServiceProviderRouter.class})
+@ContextConfiguration(initializers = {QpidRestartIT.Initializer.class})
+@Testcontainers
+public class QpidRestartIT extends QpidDockerBaseIT {
+
+    private static Path testKeysPath = getFolderPath("target/test-keys" + QpidRestartIT.class.getSimpleName());
+
+    @Container
+    public static final KeysContainer keyContainer = getKeyContainer(testKeysPath,"my_ca", "localhost", "routing_configurer", "king_gustaf", "nordea");
+
+    @Container
+    public static final QpidContainer qpidContainer = getQpidTestContainer("qpid", testKeysPath, "localhost.p12", "password", "truststore.jks", "password","localhost")
+            .dependsOn(keyContainer);
+
+    @Autowired
+    SSLContext sslContext;
+
+    private static Logger logger = LoggerFactory.getLogger(QpidRestartIT.class);
+
+    private static String AMQPS_URL;
+
+    static class Initializer
+            implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+        public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
+            qpidContainer.followOutput(new Slf4jLogConsumer(logger));
+            String httpsUrl = qpidContainer.getHttpsUrl();
+            String httpUrl = qpidContainer.getHttpUrl();
+            logger.info("server url: " + httpsUrl);
+            logger.info("server url: " + httpUrl);
+            AMQPS_URL = qpidContainer.getAmqpsUrl();
+            TestPropertyValues.of(
+                    "routing-configurer.baseUrl=" + httpsUrl,
+                    "routing-configurer.vhost=localhost",
+                    "test.ssl.trust-store=" + testKeysPath.resolve("truststore.jks"),
+                    "test.ssl.key-store=" +  testKeysPath.resolve("routing_configurer.p12")
+            ).applyTo(configurableApplicationContext.getEnvironment());
+        }
+
+    }
+
+    @MockBean
+    NeighbourService neighbourService;
+
+    @Autowired
+    ServiceProviderRouter serviceProviderRouter;
+
+    @MockBean
+    ServiceProviderRepository serviceProviderRepository;
+
+    @MockBean
+    MatchDiscoveryService matchDiscoveryService;
+
+    @MockBean
+    OutgoingMatchDiscoveryService outgoingMatchDiscoveryService;
+
+    @Autowired
+    QpidClient client;
+
+    @MockBean
+    InterchangeNodeProperties properties;
+
+    @Test
+    public void testLocalSubscriptionQueuesAreAutomaticallyAddedToQpidAfterRestart() {
+        String queueName = "loc-" + UUID.randomUUID().toString();
+
+        LocalEndpoint endpoint = new LocalEndpoint(queueName, "localhost", 5671);
+
+        String selector = "originatingCountry = 'NO'";
+
+        LocalSubscription subscription = new LocalSubscription(LocalSubscriptionStatus.CREATED, selector, "");
+        subscription.setLocalEndpoints(new HashSet<>(Collections.singleton(endpoint)));
+
+        ServiceProvider serviceProvider = new ServiceProvider(
+                "my-service-provider",
+                new Capabilities(),
+                new HashSet(Collections.singleton(subscription)),
+                Collections.emptySet(),
+                LocalDateTime.now());
+
+        serviceProviderRouter.syncServiceProviders(Collections.singletonList(serviceProvider));
+        assertThat(client.queueExists(queueName)).isTrue();
+    }
+
+    @Test
+    @Disabled
+    //Capability is not set up after restart, problems with connecting to bi-queue(and everything else)
+    public void testCapabilityExchangesAreAutomaticallyAddedToQpidAfterRestart() {
+        String exchangeName = "cap" + UUID.randomUUID().toString();
+
+        Capability capability = new DenmCapability("NO12345", "NO", "1.2.2", new HashSet<>(Collections.singletonList("0123")),  new HashSet<>(Collections.singletonList("5")));
+        capability.setCapabilityExchangeName(exchangeName);
+        capability.setRedirect(RedirectStatus.OPTIONAL);
+
+        ServiceProvider serviceProvider = new ServiceProvider(
+                "my-service-provider",
+                new Capabilities(Capabilities.CapabilitiesStatus.KNOWN, new HashSet<>(Collections.singletonList(capability))),
+                Collections.emptySet(),
+                Collections.emptySet(),
+                LocalDateTime.now());
+
+        serviceProviderRouter.syncServiceProviders(Collections.singletonList(serviceProvider));
+        assertThat(client.exchangeExists(exchangeName));
+    }
+
+    @Test
+    public void testDeliveryExchangesAreAutomaticallyAddedToQpidAfterRestart() {
+        String exchangeName = "cap-" + UUID.randomUUID().toString();
+
+        client.createTopicExchange(exchangeName);
+
+        Capability capability = new DenmCapability("NO12345", "NO", "1.2.2", new HashSet<>(Collections.singletonList("0123")),  new HashSet<>(Collections.singletonList("5")));
+        capability.setCapabilityExchangeName(exchangeName);
+        capability.setRedirect(RedirectStatus.OPTIONAL);
+
+        ServiceProvider serviceProvider = new ServiceProvider(
+                "my-service-provider",
+                new Capabilities(Capabilities.CapabilitiesStatus.KNOWN, new HashSet<>(Collections.singletonList(capability))),
+                Collections.emptySet(),
+                Collections.emptySet(),
+                LocalDateTime.now());
+
+        String deliverySelector = "originatingCountry = 'NO'";
+
+        String deliveryExchangeName = "del-" + UUID.randomUUID().toString();
+        LocalDeliveryEndpoint endpoint = new LocalDeliveryEndpoint("localhost", 5671, deliveryExchangeName, deliverySelector);
+        LocalDelivery delivery = new LocalDelivery(
+                1,
+                new HashSet<>(Collections.singletonList(endpoint)),
+                "/delivery/1",
+                deliverySelector,
+                LocalDateTime.now(),
+                LocalDeliveryStatus.CREATED);
+
+        delivery.setExchangeName(deliveryExchangeName);
+
+        serviceProvider.setDeliveries(new HashSet<>(Collections.singleton(delivery)));
+
+        OutgoingMatch match = new OutgoingMatch(delivery, capability, "my-service-provider", OutgoingMatchStatus.SETUP_ENDPOINT);
+        when(outgoingMatchDiscoveryService.findMatchesToSetupEndpointFor(any(String.class))).thenReturn(Collections.singletonList(match));
+        when(outgoingMatchDiscoveryService.findMatchesFromDeliveryId(any())).thenReturn(Collections.singletonList(match));
+        serviceProviderRouter.syncServiceProviders(Collections.singletonList(serviceProvider));
+
+        assertThat(client.exchangeExists(deliveryExchangeName)).isTrue();
+    }
+}

--- a/routing-configurer/src/test/java/no/vegvesen/ixn/federation/RoutingConfigurerQpidRestartIT.java
+++ b/routing-configurer/src/test/java/no/vegvesen/ixn/federation/RoutingConfigurerQpidRestartIT.java
@@ -3,6 +3,7 @@ package no.vegvesen.ixn.federation;
 import no.vegvesen.ixn.docker.KeysContainer;
 import no.vegvesen.ixn.docker.QpidContainer;
 import no.vegvesen.ixn.docker.QpidDockerBaseIT;
+import no.vegvesen.ixn.federation.model.*;
 import no.vegvesen.ixn.federation.properties.InterchangeNodeProperties;
 import no.vegvesen.ixn.federation.qpid.QpidClient;
 import no.vegvesen.ixn.federation.qpid.QpidClientConfig;
@@ -25,6 +26,14 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import javax.net.ssl.SSLContext;
 import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
 
 @SpringBootTest(classes = {QpidClient.class, RoutingConfigurerProperties.class, QpidClientConfig.class, TestSSLContextConfigGeneratedExternalKeys.class, TestSSLProperties.class, RoutingConfigurer.class})
 @ContextConfiguration(initializers = {RoutingConfigurerQpidRestartIT.Initializer.class})
@@ -83,7 +92,72 @@ public class RoutingConfigurerQpidRestartIT extends QpidDockerBaseIT {
     InterchangeNodeProperties properties;
 
     @Test
-    public void test() {
-        System.out.println("Hei");
+    public void testSetupRegularNeighbourSubscriptionRoutingAfterRestart() {
+        String exchangeName = "cap-" + UUID.randomUUID().toString();
+
+        Capability capability = new DenmCapability("NO12345", "NO", "1.2.2", new HashSet<>(Collections.singletonList("0123")),  new HashSet<>(Collections.singletonList("5")));
+        capability.setCapabilityExchangeName(exchangeName);
+        capability.setRedirect(RedirectStatus.OPTIONAL);
+
+        client.createTopicExchange(exchangeName);
+
+        ServiceProvider serviceProvider = new ServiceProvider(
+                "my-service-provider",
+                new Capabilities(Capabilities.CapabilitiesStatus.KNOWN, new HashSet<>(Collections.singletonList(capability))),
+                Collections.emptySet(),
+                Collections.emptySet(),
+                LocalDateTime.now());
+
+        String queueName = "sub-" + UUID.randomUUID();
+
+        NeighbourSubscription sub = new NeighbourSubscription("originatingCountry = 'NO'", NeighbourSubscriptionStatus.CREATED, "neighbour");
+        sub.setQueueName(queueName);
+
+        Neighbour neighbour = new Neighbour(
+                "neighbour",
+                new Capabilities(Capabilities.CapabilitiesStatus.KNOWN, Collections.emptySet()),
+                new NeighbourSubscriptionRequest(NeighbourSubscriptionRequestStatus.ESTABLISHED, Collections.singleton(sub)),
+                new SubscriptionRequest(SubscriptionRequestStatus.ESTABLISHED, Collections.emptySet()));
+
+
+        when(serviceProviderRouter.findServiceProviders()).thenReturn(Collections.singletonList(serviceProvider));
+        routingConfigurer.setupNeighbourRouting(neighbour);
+
+        assertThat(client.queueExists(queueName)).isFalse();
+    }
+
+    @Test
+    public void testSetupRedirectNeighbourSubscriptionRoutingAfterRestart() {
+        String exchangeName = "cap-" + UUID.randomUUID().toString();
+
+        Capability capability = new DenmCapability("NO12345", "NO", "1.2.2", new HashSet<>(Collections.singletonList("0123")),  new HashSet<>(Collections.singletonList("5")));
+        capability.setCapabilityExchangeName(exchangeName);
+        capability.setRedirect(RedirectStatus.OPTIONAL);
+
+        client.createTopicExchange(exchangeName);
+
+        ServiceProvider serviceProvider = new ServiceProvider(
+                "my-service-provider",
+                new Capabilities(Capabilities.CapabilitiesStatus.KNOWN, new HashSet<>(Collections.singletonList(capability))),
+                Collections.emptySet(),
+                Collections.emptySet(),
+                LocalDateTime.now());
+
+        String queueName = "re-" + UUID.randomUUID();
+
+        NeighbourSubscription sub = new NeighbourSubscription("originatingCountry = 'NO'", NeighbourSubscriptionStatus.CREATED, "neighbour-consumer");
+        sub.setQueueName(queueName);
+
+        Neighbour neighbour = new Neighbour(
+                "neighbour",
+                new Capabilities(Capabilities.CapabilitiesStatus.KNOWN, Collections.emptySet()),
+                new NeighbourSubscriptionRequest(NeighbourSubscriptionRequestStatus.ESTABLISHED, Collections.singleton(sub)),
+                new SubscriptionRequest(SubscriptionRequestStatus.ESTABLISHED, Collections.emptySet()));
+
+
+        when(serviceProviderRouter.findServiceProviders()).thenReturn(Collections.singletonList(serviceProvider));
+        routingConfigurer.setupNeighbourRouting(neighbour);
+
+        assertThat(client.queueExists(queueName)).isFalse();
     }
 }

--- a/routing-configurer/src/test/java/no/vegvesen/ixn/federation/RoutingConfigurerQpidRestartIT.java
+++ b/routing-configurer/src/test/java/no/vegvesen/ixn/federation/RoutingConfigurerQpidRestartIT.java
@@ -1,0 +1,89 @@
+package no.vegvesen.ixn.federation;
+
+import no.vegvesen.ixn.docker.KeysContainer;
+import no.vegvesen.ixn.docker.QpidContainer;
+import no.vegvesen.ixn.docker.QpidDockerBaseIT;
+import no.vegvesen.ixn.federation.properties.InterchangeNodeProperties;
+import no.vegvesen.ixn.federation.qpid.QpidClient;
+import no.vegvesen.ixn.federation.qpid.QpidClientConfig;
+import no.vegvesen.ixn.federation.qpid.RoutingConfigurerProperties;
+import no.vegvesen.ixn.federation.service.NeighbourService;
+import no.vegvesen.ixn.federation.ssl.TestSSLProperties;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.net.ssl.SSLContext;
+import java.nio.file.Path;
+
+@SpringBootTest(classes = {QpidClient.class, RoutingConfigurerProperties.class, QpidClientConfig.class, TestSSLContextConfigGeneratedExternalKeys.class, TestSSLProperties.class, RoutingConfigurer.class})
+@ContextConfiguration(initializers = {RoutingConfigurerQpidRestartIT.Initializer.class})
+@Testcontainers
+public class RoutingConfigurerQpidRestartIT extends QpidDockerBaseIT {
+
+    private static Path testKeysPath = getFolderPath("target/test-keys" + RoutingConfigurerQpidRestartIT.class.getSimpleName());
+
+    @Container
+    public static final KeysContainer keyContainer = getKeyContainer(testKeysPath,"my_ca", "localhost", "routing_configurer", "king_gustaf", "nordea");
+
+    @Container
+    public static final QpidContainer qpidContainer = getQpidTestContainer("qpid", testKeysPath, "localhost.p12", "password", "truststore.jks", "password","localhost")
+            .dependsOn(keyContainer);
+
+    @Autowired
+    SSLContext sslContext;
+
+    private static Logger logger = LoggerFactory.getLogger(RoutingConfigurerQpidRestartIT.class);
+
+    private static String AMQPS_URL;
+
+    static class Initializer
+            implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+        public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
+            qpidContainer.followOutput(new Slf4jLogConsumer(logger));
+            String httpsUrl = qpidContainer.getHttpsUrl();
+            String httpUrl = qpidContainer.getHttpUrl();
+            logger.info("server url: " + httpsUrl);
+            logger.info("server url: " + httpUrl);
+            AMQPS_URL = qpidContainer.getAmqpsUrl();
+            TestPropertyValues.of(
+                    "routing-configurer.baseUrl=" + httpsUrl,
+                    "routing-configurer.vhost=localhost",
+                    "test.ssl.trust-store=" + testKeysPath.resolve("truststore.jks"),
+                    "test.ssl.key-store=" +  testKeysPath.resolve("routing_configurer.p12")
+            ).applyTo(configurableApplicationContext.getEnvironment());
+        }
+
+    }
+
+    @MockBean
+    NeighbourService neighbourService;
+
+    @Autowired
+    RoutingConfigurer routingConfigurer;
+
+    @Autowired
+    QpidClient client;
+
+    @MockBean
+    ServiceProviderRouter serviceProviderRouter;
+
+    @MockBean
+    InterchangeNodeProperties properties;
+
+    @Test
+    public void test() {
+        System.out.println("Hei");
+    }
+}

--- a/routing-configurer/src/test/java/no/vegvesen/ixn/federation/SPRouterQpidRestartIT.java
+++ b/routing-configurer/src/test/java/no/vegvesen/ixn/federation/SPRouterQpidRestartIT.java
@@ -43,11 +43,11 @@ import static org.mockito.Mockito.when;
 
 
 @SpringBootTest(classes = {QpidClient.class, RoutingConfigurerProperties.class, QpidClientConfig.class, TestSSLContextConfigGeneratedExternalKeys.class, TestSSLProperties.class, ServiceProviderRouter.class})
-@ContextConfiguration(initializers = {QpidRestartIT.Initializer.class})
+@ContextConfiguration(initializers = {SPRouterQpidRestartIT.Initializer.class})
 @Testcontainers
-public class QpidRestartIT extends QpidDockerBaseIT {
+public class SPRouterQpidRestartIT extends QpidDockerBaseIT {
 
-    private static Path testKeysPath = getFolderPath("target/test-keys" + QpidRestartIT.class.getSimpleName());
+    private static Path testKeysPath = getFolderPath("target/test-keys" + SPRouterQpidRestartIT.class.getSimpleName());
 
     @Container
     public static final KeysContainer keyContainer = getKeyContainer(testKeysPath,"my_ca", "localhost", "routing_configurer", "king_gustaf", "nordea");
@@ -59,7 +59,7 @@ public class QpidRestartIT extends QpidDockerBaseIT {
     @Autowired
     SSLContext sslContext;
 
-    private static Logger logger = LoggerFactory.getLogger(QpidRestartIT.class);
+    private static Logger logger = LoggerFactory.getLogger(SPRouterQpidRestartIT.class);
 
     private static String AMQPS_URL;
 


### PR DESCRIPTION
Tested for qpid restart in RoutingConfigurer and ServiceProviderRouter. 

ServiceProviderRouter is our main concern, testing assures that service provider resources in qpid are properly set up again. 

For RoutingConfigurer we assume that resources in qpid for neighbours are removed by neighbours themselves (as if our interchange is gone) and set up again as they normally would be. 