### PR TITLE
Capabilities fix

### DIFF
--- a/neighbour-model/src/main/java/no/vegvesen/ixn/federation/model/Capabilities.java
+++ b/neighbour-model/src/main/java/no/vegvesen/ixn/federation/model/Capabilities.java
@@ -6,9 +6,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 
@@ -48,6 +46,7 @@ public class Capabilities {
 	}
 
 	public void addAllDatatypes(Set<Capability> newCapabilities) {
+		capabilities.retainAll(newCapabilities);
 		capabilities.addAll(newCapabilities);
 		if (hasDataTypes()) {
 			setStatus(CapabilitiesStatus.KNOWN);

--- a/neighbour-model/src/main/java/no/vegvesen/ixn/federation/model/Capabilities.java
+++ b/neighbour-model/src/main/java/no/vegvesen/ixn/federation/model/Capabilities.java
@@ -1,6 +1,5 @@
 package no.vegvesen.ixn.federation.model;
 
-import no.vegvesen.ixn.federation.exceptions.CapabilityPostException;
 import no.vegvesen.ixn.serviceprovider.NotFoundException;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -45,7 +44,7 @@ public class Capabilities {
 		setLastUpdated(LocalDateTime.now());
 	}
 
-	public void addAllDatatypes(Set<Capability> newCapabilities) {
+	public void replaceCapabilities(Set<Capability> newCapabilities) {
 		capabilities.retainAll(newCapabilities);
 		capabilities.addAll(newCapabilities);
 		if (hasDataTypes()) {

--- a/neighbour-model/src/test/java/no/vegvesen/ixn/federation/model/CapabilitiesTest.java
+++ b/neighbour-model/src/test/java/no/vegvesen/ixn/federation/model/CapabilitiesTest.java
@@ -1,0 +1,75 @@
+package no.vegvesen.ixn.federation.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CapabilitiesTest {
+
+    @Test
+    public void testAddAllDatatypesRetainsExistingObjects() {
+        DenmCapability firstCapability = new DenmCapability("NO00000", "NO", "DENM:1.2.2", Collections.singleton("1"), Collections.singleton("1"));
+        firstCapability.setId(1);
+        DenmCapability secondCapability = new DenmCapability("NO00001", "NO", "DENM:1.2.2", Collections.singleton("2"), Collections.singleton("2"));
+        secondCapability.setId(2);
+        Capabilities capabilities = new Capabilities(
+                Capabilities.CapabilitiesStatus.KNOWN,
+                new HashSet<>(Arrays.asList(
+                        firstCapability,
+                        secondCapability
+                )));
+        capabilities.addAllDatatypes(Collections.singleton(new DenmCapability("NO00000", "NO", "DENM:1.2.2", Collections.singleton("1"), Collections.singleton("1"))));
+        assertThat(capabilities.getCapabilities()).hasSize(1);
+        //Test that the original object is the one retained
+        assertThat(capabilities.getCapabilities().stream().findFirst().get().getId()).isEqualTo(1);
+
+    }
+
+    @Test
+    public void testAddingNewCapabilityToExistingSetReplacesIt() {
+
+        DenmCapability firstCapability = new DenmCapability("NO00000", "NO", "DENM:1.2.2", Collections.singleton("1"), Collections.singleton("1"));
+        Capabilities capabilities = new Capabilities(
+                Capabilities.CapabilitiesStatus.KNOWN,
+                new HashSet<>(Arrays.asList(
+                        firstCapability
+                )));
+        DenmCapability secondCapability = new DenmCapability("NO00001", "NO", "DENM:1.2.2", Collections.singleton("2"), Collections.singleton("2"));
+        capabilities.addAllDatatypes(Collections.singleton(secondCapability));
+        assertThat(capabilities.getCapabilities()).hasSize(1);
+        assertThat(capabilities.getCapabilities().stream().findFirst().get()).isEqualTo(secondCapability);
+    }
+
+    @Test
+    public void testAddingSeveralCapabilitiesToSingeltonSet() {
+
+        DenmCapability firstCapability = new DenmCapability("NO00000", "NO", "DENM:1.2.2", Collections.singleton("1"), Collections.singleton("1"));
+        Capabilities capabilities = new Capabilities(
+                Capabilities.CapabilitiesStatus.KNOWN,
+                new HashSet<>(Arrays.asList(
+                        firstCapability
+                )));
+        DenmCapability secondCapability = new DenmCapability("NO00001", "NO", "DENM:1.2.2", Collections.singleton("2"), Collections.singleton("2"));
+        DenmCapability thirdCapability = new DenmCapability("NO00002", "NO", "DENM:1.2.2", Collections.singleton("3"), Collections.singleton("3"));
+
+        capabilities.addAllDatatypes(new HashSet<>(Arrays.asList(secondCapability,thirdCapability)));
+        assertThat(capabilities.getCapabilities()).hasSize(2);
+        assertThat(capabilities.getCapabilities().contains(firstCapability)).isFalse();
+    }
+
+    @Test
+    public void testAddingSeveralCapabilitiesToEmptySet() {
+        Capabilities capabilities = new Capabilities(
+                Capabilities.CapabilitiesStatus.KNOWN,
+                Collections.emptySet());
+        DenmCapability firstCapability = new DenmCapability("NO00000", "NO", "DENM:1.2.2", Collections.singleton("1"), Collections.singleton("1"));
+        DenmCapability secondCapability = new DenmCapability("NO00001", "NO", "DENM:1.2.2", Collections.singleton("2"), Collections.singleton("2"));
+
+        capabilities.addAllDatatypes(new HashSet<>(Arrays.asList(firstCapability,secondCapability)));
+        assertThat(capabilities.getCapabilities()).hasSize(2);
+    }
+}

--- a/neighbour-model/src/test/java/no/vegvesen/ixn/federation/model/CapabilitiesTest.java
+++ b/neighbour-model/src/test/java/no/vegvesen/ixn/federation/model/CapabilitiesTest.java
@@ -22,7 +22,7 @@ public class CapabilitiesTest {
                         firstCapability,
                         secondCapability
                 )));
-        capabilities.addAllDatatypes(Collections.singleton(new DenmCapability("NO00000", "NO", "DENM:1.2.2", Collections.singleton("1"), Collections.singleton("1"))));
+        capabilities.replaceCapabilities(Collections.singleton(new DenmCapability("NO00000", "NO", "DENM:1.2.2", Collections.singleton("1"), Collections.singleton("1"))));
         assertThat(capabilities.getCapabilities()).hasSize(1);
         //Test that the original object is the one retained
         assertThat(capabilities.getCapabilities().stream().findFirst().get().getId()).isEqualTo(1);
@@ -39,7 +39,7 @@ public class CapabilitiesTest {
                         firstCapability
                 )));
         DenmCapability secondCapability = new DenmCapability("NO00001", "NO", "DENM:1.2.2", Collections.singleton("2"), Collections.singleton("2"));
-        capabilities.addAllDatatypes(Collections.singleton(secondCapability));
+        capabilities.replaceCapabilities(Collections.singleton(secondCapability));
         assertThat(capabilities.getCapabilities()).hasSize(1);
         assertThat(capabilities.getCapabilities().stream().findFirst().get()).isEqualTo(secondCapability);
     }
@@ -56,7 +56,7 @@ public class CapabilitiesTest {
         DenmCapability secondCapability = new DenmCapability("NO00001", "NO", "DENM:1.2.2", Collections.singleton("2"), Collections.singleton("2"));
         DenmCapability thirdCapability = new DenmCapability("NO00002", "NO", "DENM:1.2.2", Collections.singleton("3"), Collections.singleton("3"));
 
-        capabilities.addAllDatatypes(new HashSet<>(Arrays.asList(secondCapability,thirdCapability)));
+        capabilities.replaceCapabilities(new HashSet<>(Arrays.asList(secondCapability,thirdCapability)));
         assertThat(capabilities.getCapabilities()).hasSize(2);
         assertThat(capabilities.getCapabilities().contains(firstCapability)).isFalse();
     }
@@ -69,7 +69,7 @@ public class CapabilitiesTest {
         DenmCapability firstCapability = new DenmCapability("NO00000", "NO", "DENM:1.2.2", Collections.singleton("1"), Collections.singleton("1"));
         DenmCapability secondCapability = new DenmCapability("NO00001", "NO", "DENM:1.2.2", Collections.singleton("2"), Collections.singleton("2"));
 
-        capabilities.addAllDatatypes(new HashSet<>(Arrays.asList(firstCapability,secondCapability)));
+        capabilities.replaceCapabilities(new HashSet<>(Arrays.asList(firstCapability,secondCapability)));
         assertThat(capabilities.getCapabilities()).hasSize(2);
     }
 }

--- a/neighbour-service/src/main/java/no/vegvesen/ixn/federation/service/NeighbourService.java
+++ b/neighbour-service/src/main/java/no/vegvesen/ixn/federation/service/NeighbourService.java
@@ -63,7 +63,7 @@ public class NeighbourService {
 		}
 		logger.info("--- CAPABILITY POST FROM EXISTING NEIGHBOUR ---");
 		Capabilities capabilities = neighbourToUpdate.getCapabilities();
-		capabilities.addAllDatatypes(incomingCapabilities.getCapabilities());
+		capabilities.replaceCapabilities(incomingCapabilities.getCapabilities());
 		logger.info("Saving updated Neighbour: {}", neighbourToUpdate.toString());
 		neighbourRepository.save(neighbourToUpdate);
 


### PR DESCRIPTION
Makes sure that capabilities are added and removed properly, and that the retained capabilities comes from the ones that already are in the database, so that we don't have ever increasing IDs for every capability exchange.