### PR TITLE
Set qpid deployment to use Recreate as deployment strategy

### DIFF
--- a/helm/interchange/Chart.yaml
+++ b/helm/interchange/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Nordic Way Interchange app with dependencies
 name: interchange
-version: 0.5.9
+version: 0.5.10

--- a/helm/interchange/templates/qpid-deployment.yml
+++ b/helm/interchange/templates/qpid-deployment.yml
@@ -9,6 +9,8 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.qpid.replicas }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: {{ .Chart.Name }}


### PR DESCRIPTION
### Background
- We have an issue where QPID can't perform rolling updates since the PVC can only be mounted to a single k8s pod at a time.

### Changes
- Set deployment strategy to `Recreate` for QPID Deployment.