### PR TITLE
Enforce shardcount on metadata is either the set value in the api obj…

### DIFF
--- a/api-model/src/main/java/no/vegvesen/ixn/federation/api/v1_0/capability/MetadataApi.java
+++ b/api-model/src/main/java/no/vegvesen/ixn/federation/api/v1_0/capability/MetadataApi.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MetadataApi {
 
-    private Integer shardCount;
+    private Integer shardCount = 1;
 
     private String infoUrl;
 

--- a/neighbour-model/src/main/java/no/vegvesen/ixn/federation/transformer/CapabilityToCapabilityApiTransformer.java
+++ b/neighbour-model/src/main/java/no/vegvesen/ixn/federation/transformer/CapabilityToCapabilityApiTransformer.java
@@ -80,8 +80,6 @@ public class CapabilityToCapabilityApiTransformer {
 		Metadata metadata = new Metadata();
 		if (metadataApi.getShardCount() != null)
 			metadata.setShardCount(metadataApi.getShardCount());
-		else
-			metadata.setShardCount(1);
 		if (metadataApi.getInfoUrl() != null)
 			metadata.setInfoUrl(metadataApi.getInfoUrl());
 		if (metadataApi.getMaxBandwidth() != null)

--- a/neighbour-model/src/main/java/no/vegvesen/ixn/federation/transformer/CapabilityToCapabilityApiTransformer.java
+++ b/neighbour-model/src/main/java/no/vegvesen/ixn/federation/transformer/CapabilityToCapabilityApiTransformer.java
@@ -80,6 +80,8 @@ public class CapabilityToCapabilityApiTransformer {
 		Metadata metadata = new Metadata();
 		if (metadataApi.getShardCount() != null)
 			metadata.setShardCount(metadataApi.getShardCount());
+		else
+			metadata.setShardCount(1);
 		if (metadataApi.getInfoUrl() != null)
 			metadata.setInfoUrl(metadataApi.getInfoUrl());
 		if (metadataApi.getMaxBandwidth() != null)

--- a/neighbour-model/src/test/java/no/vegvesen/ixn/federation/transformer/CapabilitiesTransformerTest.java
+++ b/neighbour-model/src/test/java/no/vegvesen/ixn/federation/transformer/CapabilitiesTransformerTest.java
@@ -1,0 +1,47 @@
+package no.vegvesen.ixn.federation.transformer;
+
+import no.vegvesen.ixn.federation.api.v1_0.capability.CapabilitiesSplitApi;
+import no.vegvesen.ixn.federation.api.v1_0.capability.CapabilitySplitApi;
+import no.vegvesen.ixn.federation.api.v1_0.capability.DatexApplicationApi;
+import no.vegvesen.ixn.federation.api.v1_0.capability.MetadataApi;
+import no.vegvesen.ixn.federation.model.Capabilities;
+import no.vegvesen.ixn.federation.model.capability.CapabilitySplit;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CapabilitiesTransformerTest {
+
+    CapabilitiesTransformer transformer = new CapabilitiesTransformer();
+
+    @Test
+    public void addMetadataWithoutShardCount() {
+        HashSet<CapabilitySplitApi> capabilities = new HashSet<>();
+        capabilities.add(new CapabilitySplitApi(new DatexApplicationApi("myPublisherId", "pub-1", "NO", "pv1", Collections.emptySet(), "myPublicationType"), new MetadataApi()));
+        CapabilitiesSplitApi capabilitiesApi = new CapabilitiesSplitApi("norway", capabilities);
+
+        Capabilities caps = transformer.capabilitiesApiToCapabilities(capabilitiesApi);
+
+        CapabilitySplit cap = caps.getCapabilities().stream().findFirst().get();
+
+        assertThat(cap.getMetadata().getShardCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void addMetadataWithShardCount() {
+        HashSet<CapabilitySplitApi> capabilities = new HashSet<>();
+        MetadataApi metadataApi = new MetadataApi();
+        metadataApi.setShardCount(3);
+        capabilities.add(new CapabilitySplitApi(new DatexApplicationApi("myPublisherId", "pub-1", "NO", "pv1", Collections.emptySet(), "myPublicationType"), metadataApi));
+        CapabilitiesSplitApi capabilitiesApi = new CapabilitiesSplitApi("norway", capabilities);
+
+        Capabilities caps = transformer.capabilitiesApiToCapabilities(capabilitiesApi);
+
+        CapabilitySplit cap = caps.getCapabilities().stream().findFirst().get();
+
+        assertThat(cap.getMetadata().getShardCount()).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
…ect or set to 1 if the shardcount is null in the metadata object